### PR TITLE
Add server functionality

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,4 +36,4 @@ jobs:
           python -m pip install .[testing]
       - name: Run pytest
         run: |
-          python -m pytest -v -durations=0
+          python -m pytest -v

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,39 @@
+name: tests
+
+on:
+  push:
+    branches:
+      - main
+  release:
+    types:
+      - created
+  pull_request:
+  workflow_call:
+
+jobs:
+  tests:
+    name: Run tests
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        python-version: ["3.10", "3.11", "3.12"]
+        os: [ubuntu-latest, windows-latest, macos-latest]
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Setup python ${{ matrix.python-version }}
+        uses: actions/setup-python@v3
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Python info
+        shell: bash -e {0}
+        run: |
+          which python
+          python --version
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip setuptools
+          python -m pip install .[testing]
+      - name: Run pytest
+        run: |
+          python -m pytest -v -durations=0

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,6 +15,7 @@ jobs:
     name: Run tests
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
         python-version: ["3.10", "3.11", "3.12"]
         os: [ubuntu-latest, windows-latest, macos-latest]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,8 @@ teachbooks = "teachbooks.cli.main:main"
 
 [project.optional-dependencies]
 testing = [
-  "pytest"
+  "pytest",
+  "flaky"
 ]
 
 [tool.setuptools.packages]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,8 @@ classifiers = [
 ]
 dependencies = [
   "jupyter-book ~= 1.0",
+  "click",
+  "psutil",
   "numpy",
   "matplotlib",
   "scipy",
@@ -24,6 +26,11 @@ dependencies = [
 
 [project.scripts]
 teachbooks = "teachbooks.cli.main:main"
+
+[project.optional-dependencies]
+testing = [
+  "pytest"
+]
 
 [tool.setuptools.packages]
 find = {}

--- a/teachbooks/cli/main.py
+++ b/teachbooks/cli/main.py
@@ -56,7 +56,7 @@ def serve(ctx):
         # Hardcoded for now
         dir = Path("./book/_build/html/")
         workdir = Path("./book/.teachbooks")
-        server = Server(dir=dir, workdir=workdir)
+        server = Server(servedir=dir, workdir=workdir)
 
         server.start()
         echo_info(f"server running on {server.url}")

--- a/teachbooks/cli/main.py
+++ b/teachbooks/cli/main.py
@@ -55,7 +55,7 @@ def serve(ctx):
     if ctx.invoked_subcommand is None:
         # Hardcoded for now
         dir = Path("./book/_build/html/")
-        workdir = Path("./book/.teachbooks")
+        workdir = Path("./book/.teachbooks/server")
         server = Server(servedir=dir, workdir=workdir)
 
         server.start()
@@ -66,7 +66,7 @@ def serve(ctx):
 def stop():
     """Stop the webserver"""
     from teachbooks.serve import Server
-    server = Server.load(Path("./book/.teachbooks"))
+    server = Server.load(Path("./book/.teachbooks/server"))
     server.stop()
 
 

--- a/teachbooks/cli/main.py
+++ b/teachbooks/cli/main.py
@@ -45,6 +45,29 @@ def build(ctx, path_source, publish, process_only):
             toc=path_toc
         )
 
+@main.group(invoke_without_command=True)
+@click.pass_context
+def serve(ctx):
+    """Start a web server to interact with the book locally"""
+    from teachbooks.serve import Server
+    
+    if ctx.invoked_subcommand is None:
+        # Hardcoded for now
+        dir = Path("./book/_build/html/")
+        workdir = Path("./book/.teachbooks/serve")
+        server = Server(dir=dir, workdir=workdir)
+
+        server.start()
+
+
+@serve.command()
+def stop():
+    """Stop the webserver"""
+    from teachbooks.serve import Server
+    server = Server.load()
+    server.stop()
+
+
 
 def echo_info(message: str) -> None:
     """Wrapper for writing to stdout"""

--- a/teachbooks/cli/main.py
+++ b/teachbooks/cli/main.py
@@ -1,9 +1,6 @@
 import click
 
 from pathlib import Path
-from jupyter_book.cli.main import build as jupyter_book_build
-
-from teachbooks.publish import make_publish
 
 @click.group()
 def main():
@@ -26,6 +23,9 @@ def main():
 @click.pass_context
 def build(ctx, path_source, publish, process_only):
     """Pre-process book contents and run the Jupyter Book build command"""
+
+    from teachbooks.publish import make_publish
+    from jupyter_book.cli.main import build as jupyter_book_build
 
     strategy = "publish" if publish else "draft"
     echo_info(f"running build with strategy '{strategy}'")

--- a/teachbooks/cli/main.py
+++ b/teachbooks/cli/main.py
@@ -54,7 +54,7 @@ def serve(ctx):
     if ctx.invoked_subcommand is None:
         # Hardcoded for now
         dir = Path("./book/_build/html/")
-        workdir = Path("./book/.teachbooks/serve")
+        workdir = Path("./book/.teachbooks")
         server = Server(dir=dir, workdir=workdir)
 
         server.start()
@@ -64,7 +64,7 @@ def serve(ctx):
 def stop():
     """Stop the webserver"""
     from teachbooks.serve import Server
-    server = Server.load(Path("./book/.teachbooks/serve"))
+    server = Server.load(Path("./book/.teachbooks"))
     server.stop()
 
 

--- a/teachbooks/cli/main.py
+++ b/teachbooks/cli/main.py
@@ -1,3 +1,4 @@
+# Keep top-level imports to a minimum to improve responsiveness
 import click
 
 from pathlib import Path
@@ -58,6 +59,7 @@ def serve(ctx):
         server = Server(dir=dir, workdir=workdir)
 
         server.start()
+        echo_info(f"server running on {server.url}")
 
 
 @serve.command()
@@ -68,9 +70,7 @@ def stop():
     server.stop()
 
 
-
 def echo_info(message: str) -> None:
     """Wrapper for writing to stdout"""
     prefix = click.style("TeachBooks: ", fg="cyan", bold=True)
     click.echo(prefix + message)
-    

--- a/teachbooks/cli/main.py
+++ b/teachbooks/cli/main.py
@@ -64,7 +64,7 @@ def serve(ctx):
 def stop():
     """Stop the webserver"""
     from teachbooks.serve import Server
-    server = Server.load()
+    server = Server.load(Path("./book/.teachbooks/serve"))
     server.stop()
 
 

--- a/teachbooks/serve.py
+++ b/teachbooks/serve.py
@@ -61,8 +61,16 @@ class Server:
             self._save()
 
 
-    def stop(self) -> None: 
-        psutil.Process(pid=self._pid).terminate() 
+    def stop(self) -> None:
+        try:
+            psutil.Process(pid=self._pid).terminate()
+        except psutil.NoSuchProcess:
+            pass
+
+        if os.path.exists(self.workdir / "server" / "state.pickle"):
+            os.remove(self.workdir / "server" / "state.pickle")
+
+        self._pid = None
 
 
     def _save(self) -> None:

--- a/teachbooks/serve.py
+++ b/teachbooks/serve.py
@@ -17,6 +17,7 @@ class Server:
     def start(self) -> None:
         proc = psutil.Popen([sys.executable, "-u", "-m", "http.server"],
                             cwd=self.dir,
+                            stderr=DEVNULL,
                             stdout=DEVNULL) # Does this work on Windows?
 
         self.__pid = proc.pid

--- a/teachbooks/serve.py
+++ b/teachbooks/serve.py
@@ -44,7 +44,7 @@ class Server:
                             stdout=DEVNULL)
 
         sleep(0.1)
-        print(proc.status())
+
         # Check if the subprocess is still running
         if proc.status() != "running":
             proc.terminate()

--- a/teachbooks/serve.py
+++ b/teachbooks/serve.py
@@ -39,7 +39,7 @@ class Server:
         if self.port is None:
             self.port = self._find_port()
         
-        proc = psutil.Popen([sys.executable, "-u", "-m", "http.server", '0'],
+        proc = psutil.Popen([sys.executable, "-u", "-m", "http.server", str(self.port)],
                             cwd=self.dir,
                             stdout=DEVNULL)
 

--- a/teachbooks/serve.py
+++ b/teachbooks/serve.py
@@ -15,6 +15,10 @@ from typing import TypeVar, Type
 Server_t = TypeVar("Server_t", bound="Server")
 
 
+class ServerError(Exception):
+    pass
+
+
 @dataclass
 class Server:
     dir: Path | str
@@ -73,6 +77,9 @@ class Server:
 
     @staticmethod
     def load(workdir) -> Server_t:
-        with open(workdir / "server" / "state.pickle", "rb") as f:
-            server = pickle.load(f)
+        try:
+            with open(workdir / "server" / "state.pickle", "rb") as f:
+                server = pickle.load(f)
+        except FileNotFoundError as exc:
+            raise ServerError("Server information not found.") from exc
         return server

--- a/teachbooks/serve.py
+++ b/teachbooks/serve.py
@@ -39,7 +39,7 @@ class Server:
         if self.port is None:
             self.port = self._find_port()
         
-        proc = psutil.Popen([sys.executable, "-u", "-m", "http.server", str(self.port)],
+        proc = psutil.Popen([sys.executable, "-u", "-m", "http.server", 0],
                             cwd=self.dir,
                             stderr=DEVNULL,
                             stdout=DEVNULL)

--- a/teachbooks/serve.py
+++ b/teachbooks/serve.py
@@ -21,8 +21,9 @@ class Server:
     __pid: int | None = None
 
     def __post_init__(self):
-        if not os.path.exists(self.workdir):
-            os.makedirs(self.workdir)
+
+        if not os.path.exists(self.workdir / "server"):
+            os.makedirs(self.workdir / "server")
 
     def start(self) -> None:
         proc = psutil.Popen([sys.executable, "-u", "-m", "http.server"],
@@ -45,12 +46,12 @@ class Server:
 
 
     def _save(self) -> None:
-        with open(self.workdir / "state.pickle", "wb") as f:
+        with open(self.workdir / "server" / "state.pickle", "wb") as f:
             pickle.dump(self, f)
 
 
     @staticmethod
     def load(workdir) -> Server_t:
-        with open(workdir / "state.pickle", "rb") as f:
+        with open(workdir / "server" / "state.pickle", "rb") as f:
             server = pickle.load(f)
         return server

--- a/teachbooks/serve.py
+++ b/teachbooks/serve.py
@@ -2,6 +2,7 @@ import pickle
 import sys
 import os
 import socket
+import platform
 
 import psutil
 
@@ -11,6 +12,12 @@ from dataclasses import dataclass
 from http.server import HTTPServer, BaseHTTPRequestHandler
 from time import sleep
 from typing import TypeVar, Type
+
+STATUS = {
+    "Linux": "sleeping",
+    "Darwin": "running",
+    "Windows": "running"
+}
 
 Server_t = TypeVar("Server_t", bound="Server")
 
@@ -46,7 +53,7 @@ class Server:
         sleep(0.1)
 
         # Check if the subprocess is still running
-        if proc.status() != "running":
+        if proc.status() != STATUS[platform.system()]:
             proc.terminate()
             raise RuntimeError("Error launching the server. Perhaps a server is already running on the selected port?")
         else:

--- a/teachbooks/serve.py
+++ b/teachbooks/serve.py
@@ -44,7 +44,7 @@ class Server:
                             stdout=DEVNULL)
 
         sleep(0.1)
-
+        print(proc.status())
         # Check if the subprocess is still running
         if proc.status() != "running":
             proc.terminate()

--- a/teachbooks/serve.py
+++ b/teachbooks/serve.py
@@ -26,12 +26,14 @@ class Server:
     port: int | None = None
     _pid: int | None = None
 
+
     def __post_init__(self):
         self.dir = Path(self.dir)
         self.workdir = Path(self.workdir)
 
         if not os.path.exists(self.workdir / "server"):
             os.makedirs(self.workdir / "server")
+
 
     def start(self) -> None:
         # Check for an existing server and stop it
@@ -46,21 +48,21 @@ class Server:
         proc = psutil.Popen([sys.executable, "-u", "-m", "http.server", str(self.port)],
                             cwd=self.dir,
                             stderr=DEVNULL,
-                            stdout=DEVNULL) # Does this work on Windows?
+                            stdout=DEVNULL)
 
         sleep(0.1)
 
         # Check if the subprocess is still running
         if proc.status() != "running":
             proc.terminate()
-            raise RuntimeError("Error launching the server. Perhaps a server is already running?")
+            raise RuntimeError("Error launching the server. Perhaps a server is already running on the selected port?")
         else:
             self._pid = proc.pid
             self._save()
 
 
     def stop(self) -> None: 
-        psutil.Process(pid=self._pid).terminate()        
+        psutil.Process(pid=self._pid).terminate() 
 
 
     def _save(self) -> None:
@@ -70,7 +72,7 @@ class Server:
 
     @property
     def url(self) -> str:
-        return f"http://localhost:{self.port}" 
+        return f"http://localhost:{self.port}"
 
 
     @staticmethod
@@ -79,7 +81,7 @@ class Server:
         sock = socket.socket()
         sock.bind(('', 0))
         return sock.getsockname()[1]
-        
+
 
     @staticmethod
     def load(workdir) -> Server_t:

--- a/teachbooks/serve.py
+++ b/teachbooks/serve.py
@@ -34,6 +34,12 @@ class Server:
             os.makedirs(self.workdir / "server")
 
     def start(self) -> None:
+        # Check for an existing server and stop it
+        try:
+            self.load(self.workdir).stop()
+        except (ServerError, psutil.NoSuchProcess):
+            pass
+
         if self.port is None:
             self.port = self._find_port()
         

--- a/teachbooks/serve.py
+++ b/teachbooks/serve.py
@@ -36,12 +36,6 @@ class Server:
 
 
     def start(self) -> None:
-        # Check for an existing server and stop it
-        try:
-            self.load(self.workdir).stop()
-        except (ServerError, psutil.NoSuchProcess):
-            pass
-
         if self.port is None:
             self.port = self._find_port()
         

--- a/teachbooks/serve.py
+++ b/teachbooks/serve.py
@@ -60,7 +60,7 @@ class Server:
 
     @property
     def url(self) -> str:
-        return f"localhost:{self.port}" 
+        return f"http://localhost:{self.port}" 
 
 
     @staticmethod

--- a/teachbooks/serve.py
+++ b/teachbooks/serve.py
@@ -1,0 +1,34 @@
+import pickle
+
+import psutil
+
+from subprocess import DEVNULL
+from pathlib import Path
+from dataclasses import dataclass
+
+
+@dataclass
+class Server:
+    dir: Path
+    workdir: Path
+    __pid: int = None
+
+    def start(self) -> None:
+        proc = psutil.Popen(["python", "-u", "-m", "http.server"],
+                            stdout=DEVNULL) # Does this work on Windows?
+
+        self.__pid = proc.pid
+        self._save()
+
+    def stop(self) -> None: psutil.Process(pid=self.__pid).terminate()        
+
+
+    def _save(self) -> None:
+        with open("test", "wb") as f:
+            pickle.dump(self, f)
+
+    @staticmethod
+    def load() -> None:
+        with open("test", "rb") as f:
+            data = pickle.load(f)
+        return data

--- a/teachbooks/serve.py
+++ b/teachbooks/serve.py
@@ -41,7 +41,6 @@ class Server:
         
         proc = psutil.Popen([sys.executable, "-u", "-m", "http.server", '0'],
                             cwd=self.dir,
-                            stderr=DEVNULL,
                             stdout=DEVNULL)
 
         sleep(0.1)

--- a/teachbooks/serve.py
+++ b/teachbooks/serve.py
@@ -39,7 +39,7 @@ class Server:
         if self.port is None:
             self.port = self._find_port()
         
-        proc = psutil.Popen([sys.executable, "-u", "-m", "http.server", 0],
+        proc = psutil.Popen([sys.executable, "-u", "-m", "http.server", '0'],
                             cwd=self.dir,
                             stderr=DEVNULL,
                             stdout=DEVNULL)

--- a/teachbooks/serve.py
+++ b/teachbooks/serve.py
@@ -1,4 +1,5 @@
 import pickle
+import sys
 
 import psutil
 
@@ -14,7 +15,8 @@ class Server:
     __pid: int = None
 
     def start(self) -> None:
-        proc = psutil.Popen(["python", "-u", "-m", "http.server"],
+        proc = psutil.Popen([sys.executable, "-u", "-m", "http.server"],
+                            cwd=self.dir,
                             stdout=DEVNULL) # Does this work on Windows?
 
         self.__pid = proc.pid

--- a/teachbooks/serve.py
+++ b/teachbooks/serve.py
@@ -26,13 +26,13 @@ class Server:
         self.dir = Path(self.dir)
         self.workdir = Path(self.workdir)
 
-        if self.port is None:
-            self.port = self._find_port()
-
         if not os.path.exists(self.workdir / "server"):
             os.makedirs(self.workdir / "server")
 
     def start(self) -> None:
+        if self.port is None:
+            self.port = self._find_port()
+        
         proc = psutil.Popen([sys.executable, "-u", "-m", "http.server", str(self.port)],
                             cwd=self.dir,
                             stderr=DEVNULL,

--- a/teachbooks/serve.py
+++ b/teachbooks/serve.py
@@ -78,7 +78,7 @@ class Server:
 
             self._pid = proc.pid
 
-            sleep(0.1)
+            sleep(0.2)
 
             # Check if the subprocess is still running
             if not self.is_running:
@@ -123,7 +123,7 @@ class Server:
         except psutil.NoSuchProcess:
             return False
         isalive = proc.status() == STATUS[platform.system()]
-        isserver = proc.cmdline() == [sys.executable, "-u", "-m", "http.server", str(self.port)]
+        isserver = proc.cmdline()[1:] == ["-u", "-m", "http.server", str(self.port)]
         return isalive and isserver
 
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1,7 +1,8 @@
-import pytest
 import os
-
 from pathlib import Path
+
+import pytest
+from flaky import flaky
 
 from teachbooks.serve import Server
 
@@ -32,14 +33,15 @@ def test_create(port):
     assert server._pid == None
     assert server._statepath == Path("./.teachbooks/state.pickle")
 
-
+@flaky(max_runs=10)
 def test_start(running_server):
     server = running_server
     assert server.port is not None
     assert server._pid is not None
     assert server.url == f"http://localhost:{server.port}"
 
-    
+ 
+@flaky(max_runs=10)
 def test_save_and_load(running_server):
     running_server._save()
     
@@ -51,6 +53,7 @@ def test_save_and_load(running_server):
     assert new_server._statepath == running_server._statepath
 
 
+@flaky(max_runs=10)
 def test_stop(server):
     server.start()
     server.stop()

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -60,3 +60,11 @@ def test_stop(server):
     
     assert not os.path.exists(WORK_DIR / "state.pickle")
     assert server._pid == None
+
+@flaky(max_runs=10)
+def test_multiple_start(running_server):
+    pid, port = running_server._pid, running_server.port
+    running_server.start()
+    assert running_server._pid == pid
+    assert running_server.port == port
+    

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -11,7 +11,7 @@ WORK_DIR = Path("./.teachbooks")
 
 @pytest.fixture
 def server():
-    server = Server(dir=SERVE_DIR, workdir=WORK_DIR, port=8000)
+    server = Server(dir=SERVE_DIR, workdir=WORK_DIR)
     return server
 
 @pytest.fixture
@@ -36,7 +36,7 @@ def test_start(running_server):
     server = running_server
     assert server.port is not None
     assert server._pid is not None
-    assert server.url == "http://localhost:8000"
+    assert server.url == f"http://localhost:{server.port}"
 
     
 def test_save_and_load(running_server):

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -11,7 +11,7 @@ WORK_DIR = Path("./.teachbooks")
 
 @pytest.fixture
 def server():
-    server = Server(dir=SERVE_DIR, workdir=WORK_DIR)
+    server = Server(servedir=SERVE_DIR, workdir=WORK_DIR)
     return server
 
 @pytest.fixture
@@ -25,11 +25,12 @@ def running_server(server):
     "port", [None, 8000]
 )
 def test_create(port):
-    server = Server(dir=SERVE_DIR, workdir=WORK_DIR, port=port)
-    assert server.dir == Path(".")
+    server = Server(servedir=SERVE_DIR, workdir=WORK_DIR, port=port)
+    assert server.servedir == Path(".")
     assert server.workdir == Path("./.teachbooks")
     assert server.port == port
     assert server._pid == None
+    assert server._statepath == Path("./.teachbooks/state.pickle")
 
 
 def test_start(running_server):
@@ -43,15 +44,16 @@ def test_save_and_load(running_server):
     running_server._save()
     
     new_server = Server.load(WORK_DIR)
-    assert new_server.dir == running_server.dir
+    assert new_server.servedir == running_server.servedir
     assert new_server.workdir == running_server.workdir
     assert new_server.port == running_server.port
     assert new_server._pid == running_server._pid
+    assert new_server._statepath == running_server._statepath
 
 
 def test_stop(server):
     server.start()
     server.stop()
     
-    assert not os.path.exists(WORK_DIR / "server" / "state.pickle")
+    assert not os.path.exists(WORK_DIR / "state.pickle")
     assert server._pid == None

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1,0 +1,57 @@
+import pytest
+import os
+
+from pathlib import Path
+
+from teachbooks.serve import Server
+
+SERVE_DIR = Path(".")
+WORK_DIR = Path("./.teachbooks")
+
+
+@pytest.fixture
+def server():
+    server = Server(dir=SERVE_DIR, workdir=WORK_DIR, port=8000)
+    return server
+
+@pytest.fixture
+def running_server(server):
+    server.start()
+    yield server
+    server.stop()
+
+
+@pytest.mark.parametrize(
+    "port", [None, 8000]
+)
+def test_create(port):
+    server = Server(dir=SERVE_DIR, workdir=WORK_DIR, port=port)
+    assert server.dir == Path(".")
+    assert server.workdir == Path("./.teachbooks")
+    assert server.port == port
+    assert server._pid == None
+
+
+def test_start(running_server):
+    server = running_server
+    assert server.port is not None
+    assert server._pid is not None
+    assert server.url == "http://localhost:8000"
+
+    
+def test_save_and_load(running_server):
+    running_server._save()
+    
+    new_server = Server.load(WORK_DIR)
+    assert new_server.dir == running_server.dir
+    assert new_server.workdir == running_server.workdir
+    assert new_server.port == running_server.port
+    assert new_server._pid == running_server._pid
+
+
+def test_stop(server):
+    server.start()
+    server.stop()
+    
+    assert not os.path.exists(WORK_DIR / "server" / "state.pickle")
+    assert server._pid == None


### PR DESCRIPTION
The `serve` command to launch a Python web server for viewing a book locally and use the interactive features.

Tasks:
- [x] Extend Click CLI with `serve` and `serve stop` command
- [x] Figure out a way to keep track of the PID of the web server
- [x] Check for free port
- [x] Check for already running servers
- [x] Stop the output of the subprocess from displaying in the terminal
- [x] Add tests
- [x] Clean up state after system reboot or manual termination of the web server subprocess
- [x] Test on Windows
- [ ] Add some verbosity