### PR TITLE
Added release option

### DIFF
--- a/teachbooks/publish.py
+++ b/teachbooks/publish.py
@@ -1,12 +1,10 @@
 import re
 import os
-
 from pathlib import Path
 
 
 def make_publish(sourcedir: Path) -> tuple[Path, Path]:
     """Pre-process files in a Jupyter Book directory"""
-
     # Make hidden directory that will contain the cleaned-up files
     workdir = sourcedir.joinpath(".teachbooks", "publish")
 
@@ -23,8 +21,8 @@ def make_publish(sourcedir: Path) -> tuple[Path, Path]:
 
 
 def clean_yaml(path_source: str | Path, path_output: str | Path) -> None:
-    """Removes sections marked with # <START|END> REMOVE-FROM-PUBLISH from a yaml file
-    
+    """Removes sections marked with # <START|END> REMOVE-FROM-PUBLISH or REMOVE-FROM-RELEASE from a yaml file
+
     Does not require a specific indentation and can be used an unlimited number of times
     in the `*.yml` file. Commonly applied to `_toc.yml` and `_config.yml` files of a book.
 
@@ -36,6 +34,9 @@ def clean_yaml(path_source: str | Path, path_output: str | Path) -> None:
     # START REMOVE-FROM-PUBLISH
       - file: subdirectory_1/sub_page_2
     # END REMOVE-FROM-PUBLISH
+    # START REMOVE-FROM-RELEASE
+      - file: subdirectory_1/sub_page_3
+    # END REMOVE-FROM-RELEASE
     - file: subdirectory_2/intro_page
     ```
     """
@@ -43,9 +44,10 @@ def clean_yaml(path_source: str | Path, path_output: str | Path) -> None:
     with open(path_source, mode="r", encoding="utf8") as f:
         yaml_source = f.read()
 
+    # Regex to remove both PUBLISH and RELEASE tags
     yaml_output = re.sub(
-        r"# START REMOVE-FROM-PUBLISH(.|\n)*?# END REMOVE-FROM-PUBLISH", 
-        "", 
+        r"# START REMOVE-FROM-(PUBLISH|RELEASE)(.|\n)*?# END REMOVE-FROM-(PUBLISH|RELEASE)",
+        "",
         yaml_source
     )
 


### PR DESCRIPTION
This pull request regards issue #16 #17.

For issue #16 , a comment message was added to the '--publish' option in order to warn the users to use the '--release' option instead. 

For issue #17 , the '--release' option was added, which takes over the functionality of '--publish' option. 
It was also made sure that the 'teachbook build --release' works with both tags - RELEASE and PUBLISH.
