### PR TITLE
Teachbooks clean

### DIFF
--- a/teachbooks/cli/main.py
+++ b/teachbooks/cli/main.py
@@ -59,6 +59,31 @@ def build(ctx, path_source, publish, release, process_only):
         )
 
 
+@main.command()
+@click.argument("path-source", type=click.Path(exists=True, file_okay=True))
+def clean(path_source):
+    """Clean up book build artifacts."""
+    from jupyter_book.cli.main import clean as jupyter_book_clean
+    from teachbooks.serve import Server, ServerError
+
+    workdir = Path(path_source) / ".teachbooks" / "server"
+
+    # Check if a server is running and stop it if so
+    try:
+        server = Server.load(workdir)
+        if server.is_running:
+            echo_info("Stopping running server before cleaning...")
+            server.stop()
+            echo_info("Server stopped.")
+    except ServerError:
+        echo_info("No running server found.")
+
+    # Now proceed with cleaning
+    echo_info(f"Cleaning build artifacts in {path_source}...")
+    jupyter_book_clean.main([str(path_source)])
+    echo_info("Clean complete.")
+
+
 @main.group(invoke_without_command=True)
 @click.pass_context
 def serve(ctx):

--- a/teachbooks/cli/main.py
+++ b/teachbooks/cli/main.py
@@ -62,7 +62,7 @@ def build(ctx, path_source, publish, release, process_only):
 @main.command()
 @click.argument("path-source", type=click.Path(exists=True, file_okay=True))
 def clean(path_source):
-    """Clean up book build artifacts."""
+    """Stop teachbooks server and run Jupyter Book clean command."""
     from jupyter_book.cli.main import clean as jupyter_book_clean
     from teachbooks.serve import Server, ServerError
 

--- a/teachbooks/publish.py
+++ b/teachbooks/publish.py
@@ -1,12 +1,10 @@
 import re
 import os
-
 from pathlib import Path
 
 
 def make_publish(sourcedir: Path) -> tuple[Path, Path]:
     """Pre-process files in a Jupyter Book directory"""
-
     # Make hidden directory that will contain the cleaned-up files
     workdir = sourcedir.joinpath(".teachbooks", "publish")
 
@@ -23,8 +21,8 @@ def make_publish(sourcedir: Path) -> tuple[Path, Path]:
 
 
 def clean_yaml(path_source: str | Path, path_output: str | Path) -> None:
-    """Removes sections marked with # <START|END> REMOVE-FROM-PUBLISH from a yaml file
-    
+    """Removes sections marked with # <START|END> REMOVE-FROM-PUBLISH or REMOVE-FROM-RELEASE from a yaml file
+
     Does not require a specific indentation and can be used an unlimited number of times
     in the `*.yml` file. Commonly applied to `_toc.yml` and `_config.yml` files of a book.
 
@@ -36,6 +34,9 @@ def clean_yaml(path_source: str | Path, path_output: str | Path) -> None:
     # START REMOVE-FROM-PUBLISH
       - file: subdirectory_1/sub_page_2
     # END REMOVE-FROM-PUBLISH
+    # START REMOVE-FROM-RELEASE
+      - file: subdirectory_1/sub_page_3
+    # END REMOVE-FROM-RELEASE
     - file: subdirectory_2/intro_page
     ```
     """
@@ -43,9 +44,10 @@ def clean_yaml(path_source: str | Path, path_output: str | Path) -> None:
     with open(path_source, mode="r", encoding="utf8") as f:
         yaml_source = f.read()
 
+    # Regex to remove both PUBLISH and RELEASE tags
     yaml_output = re.sub(
-        r"# START REMOVE-FROM-PUBLISH(.|\n)*?# END REMOVE-FROM-PUBLISH", 
-        "", 
+        r"# START REMOVE-FROM-(PUBLISH|RELEASE)(.|\n)*?# END REMOVE-FROM-(PUBLISH|RELEASE)",
+        "",
         yaml_source
     )
 

--- a/teachbooks/serve.py
+++ b/teachbooks/serve.py
@@ -65,6 +65,11 @@ class Server:
         RuntimeError
             If server could not be started
         """
+        print(f"Serving directory: {self.servedir}")  # Print the directory being served
+        if not self.servedir.is_dir():
+            raise NotADirectoryError(f"Directory does not exist: {self.servedir}")
+
+
         if self.port is None:
             self.port = self._find_port()
         


### PR DESCRIPTION
This pull request regards issue #19 .

The 'teachbooks clean' command has been added, where the command shuts down the server if there were any running, and cleans up the artifact. 

Most of the changes were made in cli/main.py, where the clean method was implemented (line 64~84) along with the comments.

A small exception throw condition was added in teachbooks/serve.py, in order to make sure that the directory actually exists. (line 68~70)