### PR TITLE
Release command outputs an stderr message

### DIFF
--- a/teachbooks/cli/main.py
+++ b/teachbooks/cli/main.py
@@ -1,6 +1,10 @@
 import click
 from pathlib import Path
 
+
+
+
+
 @click.group()
 def main():
     """TeachBooks command line tools"""
@@ -22,7 +26,9 @@ def build(ctx, path_source, publish, release, process_only):
     from jupyter_book.cli.main import build as jupyter_book_build
 
     if publish:
-        click.echo(click.style("--publish is deprecated, use --release", fg="yellow"))
+        click.secho("Warning: --publish is deprecated, use --release instead",
+                   fg="yellow",
+                   err=True)
 
     strategy = "release" if release or publish else "draft"
     echo_info(f"running build with strategy '{strategy}'")

--- a/test/_config.yml
+++ b/test/_config.yml
@@ -1,0 +1,25 @@
+title: Junwon's book
+author: Junwon
+copyright: "2024"
+
+repository:
+  url: https://github.com/junwon1022/delft
+  branch: main
+
+execute:
+  execute_notebooks: auto
+
+sphinx:
+  extra_extensions:
+    - sphinx.ext.intersphinx
+
+parse:
+  myst_enable_extensions:
+    - amsmath
+    - dollarmath
+    - linkify
+
+html:
+  use_repository_button: true
+  use_issues_button: true
+  use_edit_page_button: true

--- a/test/_toc.yml
+++ b/test/_toc.yml
@@ -1,0 +1,5 @@
+format: jb-book
+root: index
+chapters:
+  - file: chapter1
+  - file: chapter2

--- a/test/chapter1.md
+++ b/test/chapter1.md
@@ -1,0 +1,5 @@
+# Chapter 1
+
+Content for chapter 1...
+
+blahblahblah

--- a/test/chapter2.md
+++ b/test/chapter2.md
@@ -1,0 +1,3 @@
+# Chapter 2
+
+Content for chapter 2...

--- a/test/index.md
+++ b/test/index.md
@@ -1,0 +1,3 @@
+# Welcome to Junwon's book
+
+Introduction text here...


### PR DESCRIPTION
This pull request regards issue #23 .

Changes made:
- Modified --release command's warning message to use click.secho with err=True
- Added "Warning:" prefix and used yellow text color for clearer message type indication
- Ensures warning messages don't interfere with normal program output

The warning will now appear in error logs and won't affect programs parsing the normal output stream.

Moreover, Test files have been added to the 'test' repository for testing purposes.

![image](https://github.com/user-attachments/assets/f3b8039c-faa9-430f-bb66-3ea517b06c3d)
