### PR TITLE
Showing final build size

### DIFF
--- a/teachbooks/cli/main.py
+++ b/teachbooks/cli/main.py
@@ -21,7 +21,6 @@ def build(ctx, path_source, publish, release, process_only):
     """Pre-process book contents and run Jupyter Book build command"""
     from teachbooks.release import make_publish
     from jupyter_book.cli.main import build as jupyter_book_build
-    import os
 
     if publish:
         click.secho("Warning: --publish is deprecated, use --release instead",

--- a/teachbooks/cli/main.py
+++ b/teachbooks/cli/main.py
@@ -2,9 +2,6 @@ import click
 from pathlib import Path
 
 
-
-
-
 @click.group()
 def main():
     """TeachBooks command line tools"""
@@ -24,11 +21,12 @@ def build(ctx, path_source, publish, release, process_only):
     """Pre-process book contents and run Jupyter Book build command"""
     from teachbooks.release import make_publish
     from jupyter_book.cli.main import build as jupyter_book_build
+    import os
 
     if publish:
         click.secho("Warning: --publish is deprecated, use --release instead",
-                   fg="yellow",
-                   err=True)
+                    fg="yellow",
+                    err=True)
 
     strategy = "release" if release or publish else "draft"
     echo_info(f"running build with strategy '{strategy}'")
@@ -41,21 +39,21 @@ def build(ctx, path_source, publish, release, process_only):
         path_toc = path_src_folder / "_toc.yml"
 
     if not process_only:
-        # Start with base arguments
         all_args = [str(path_src_folder)]
-
-        # Add config and toc if they exist
         if path_conf and path_conf.exists():
             all_args.extend(["--config", str(path_conf)])
         if path_toc and path_toc.exists():
             all_args.extend(["--toc", str(path_toc)])
-
-        # Add all original args, preserving their order and values
         if ctx.args:
             all_args.extend(ctx.args)
 
-        # Pass through all args to jupyter-book
         jupyter_book_build.main(args=all_args, standalone_mode=False)
+
+        # Calculate and report build size
+        build_dir = path_src_folder / "_build"
+        total_size = sum(f.stat().st_size for f in build_dir.rglob('*') if f.is_file())
+        size_mb = total_size / (1024 * 1024)
+        echo_info(f"Build complete. Total size: {size_mb:.2f}MB")
 
 
 @main.command()


### PR DESCRIPTION
This pull request regards part of the issue #12 .

Now the terminal shows the final build size after executing "teachbooks build /path/to/book".
The changes were made in the 'build' method in main.py file. 

Currently the function only applies when building the book, but a different command such as 'teachbooks inspect' (as @rlanzafame has mentioned) could be implemented later by extending from the current code.

![image](https://github.com/user-attachments/assets/edb00c69-6ebc-4561-bc99-2a5b0d2cf280)
