### PR TITLE
temp dir changed to .teachbooks/release closes #42

### DIFF
--- a/teachbooks/release.py
+++ b/teachbooks/release.py
@@ -6,7 +6,7 @@ from pathlib import Path
 def make_publish(sourcedir: Path) -> tuple[Path, Path]:
     """Pre-process files in a Jupyter Book directory"""
     # Make hidden directory that will contain the cleaned-up files
-    workdir = sourcedir.joinpath(".teachbooks", "publish")
+    workdir = sourcedir.joinpath(".teachbooks", "release")
 
     if not os.path.exists(workdir):
         os.makedirs(workdir)


### PR DESCRIPTION
The temp directory was pointing to  ".teachbooks/publish", now has been changed to ".teachbooks/release"

closes #42