### PR TITLE
improved directory structure and arguments

### DIFF
--- a/teachbooks/cli/main.py
+++ b/teachbooks/cli/main.py
@@ -87,20 +87,36 @@ def serve(ctx):
     from teachbooks.serve import Server
 
     if ctx.invoked_subcommand is None:
-        # Hardcoded for now
-        dir = Path("./book")
-        workdir = Path("./book/.teachbooks/server")
-        server = Server(servedir=dir, workdir=workdir)
+        ctx.forward(start)
 
-        server.start(options=["--all"])
-        echo_info(f"server running on {server.url}")
 
+@serve.command()
+@click.argument("path", type=click.Path(exists=True, file_okay=False), required=False)
+def start(path=None):
+    # Hardcoded for now
+    """Start the webserver"""
+    from teachbooks.serve import Server
+    # dir = Path(path) if path else Path("./book")
+    if path and Path(path+"/_build/html").exists():
+        dir = Path(path+"/_build/html")
+    elif Path("./book/_build/html").exists():
+        dir = Path("./book/_build/html")
+    else:
+        dir = Path("")
+        click.secho(f"Warning: Default directory '{dir}' not found. Serving current directory.", fg="yellow")
+
+    workdir = Path(".teachbooks/server")
+    server = Server(servedir=dir, workdir=workdir)
+    server.start(options=["--all"])
+    echo_info(f"Starting server with path: {dir}")
+    echo_info(f"Server running on {server.url}")
 
 @serve.command()
 def stop():
     """Stop the webserver"""
     from teachbooks.serve import Server
-    server = Server.load(Path("./book/.teachbooks/server"))
+    # server = Server.load(Path("./book/.teachbooks/server"))
+    server = Server.load(Path(".teachbooks/server"))
     server.stop()
     echo_info(f"server stopped")
 


### PR DESCRIPTION
### Summary
- Directory structure doesn't go to wrong directory. 
- Also implemented a "start" sub command.

### New Changes
- for default "book" folder
```bash
teachbooks build --release book
teachbooks serve    # or # teachbooks serve start book
teachbooks serve stop
```
##### OR
- For Dynamic pathing the folder name can be anything not just "book"
```bash
teachbooks build --release anybook
teachbooks serve start anybook
teachbooks serve stop
```
- Added new start sub-command to differentiate between stop sub-command better
### Testing Results
- Verified all commands work as intended in the new structure.
- Tested compatibility with existing functionality.
```bash
C:\open_contribution\teachbooks>teachbooks build --release anybook
TeachBooks: running build with strategy 'release'
...
TeachBooks: Build complete. Total size: 6.61MB

C:\open_contribution\teachbooks>teachbooks serve start anybook
Serving directory: anybook\_build\html
Starting server with command: C:\Python\python.exe -u -m http.server 55421 --all
TeachBooks: Starting server with path: anybook\_build\html
TeachBooks: Server running on http://localhost:55421

C:\open_contribution\teachbooks>teachbooks serve stop
TeachBooks: server stopped

C:\open_contribution\teachbooks>teachbooks clean anybook
TeachBooks: No running server found.
TeachBooks: Cleaning build artifacts in anybook...
...

C:\open_contribution\teachbooks>
```
