### PR TITLE
A few adjustments to external content for v0.2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This Python package is primarily a wrapper around the Jupyter Book package and is designed to facilitate usage of the platform in educational contexts. In this case "wrapper" refers to the CLI usage: CLI commands generally invoke `jupyter-book` commands internally; the `jupyter-book` package is _not_ distributed within the `teachbooks` package.
 
-The source code and function of the package is documented on a Sphinx-built website: [teachbooks.io/TeachBooks/](https://teachbooks.io/TeachBooks/). Visit the TeachBooks [website](https://teachbooks.io) and [manual](https://teachbooks.io/manual) to learn more about how this package is used in an educational context.
+The source code and function of the package is documented at [teachbooks.readthedocs.io](https://teachbooks.readthedocs.io). Visit the TeachBooks [website](https://teachbooks.io) and [manual](https://teachbooks.io/manual) to learn more about how this package is used in an educational context.
 
 The package is currently [available on PyPI](https://pypi.org/project/teachbooks/) only and can be installed as follows:
 
@@ -53,7 +53,9 @@ New features and improvements are incorporated via pull requests to the (default
 
 ### Documentation Website
 
-The [documentation for this package](https://teachbooks.io/teachbooks) is built using Sphinx and @pradyunsg's Furo; use the [Furo documentation](https://pradyunsg.me/furo/#) as a reference when updating the documentation site.
+The documentation for this package is built using Sphinx and @pradyunsg's Furo; use the [Furo documentation](https://pradyunsg.me/furo/#) as a reference when updating the documentation site.
+
+The Read the Docs website [teachbooks.readthedocs.io](https://teachbooks.readthedocs.io) maintains documentation for each tagged release beginning with version `0.2.0`. The documentation website is also deployed from GitHub Pages from the `stable` branch and can be accessed at [teachbooks.io/TeachBooks/](https://teachbooks.io/TeachBooks/). This should remain identical to the "latest" (default) Read the Docs documentation page as long as the most recent tagged release is on branch `stable`.
 
 ### Development Setup
 

--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 This Python package is primarily a wrapper around the Jupyter Book package and is designed to facilitate usage of the platform in educational contexts. In this case "wrapper" refers to the CLI usage: CLI commands generally invoke `jupyter-book` commands internally; the `jupyter-book` package is _not_ distributed within the `teachbooks` package.
 
-The source code and function of the package is documented at [teachbooks.readthedocs.io](https://teachbooks.readthedocs.io). Visit the TeachBooks [website](https://teachbooks.io) and [manual](https://teachbooks.io/manual) to learn more about how this package is used in an educational context.
+The source code and function of the package is documented at [teachbooks.readthedocs.io](https://teachbooks.readthedocs.io). Visit the TeachBooks [website](https://teachbooks.io) and [dedicated Manual page](https://teachbooks.io/manual/features/overview.html#teachbooks-python-package) to learn more about how this package is used in an educational context.
 
-The package is currently [available on PyPI](https://pypi.org/project/teachbooks/) only and can be installed as follows:
+The package is currently [available on PyPI](https://pypi.org/project/teachbooks/) and can be installed as follows:
 
 ```
 pip install teachbooks
@@ -14,8 +14,9 @@ pip install teachbooks
 
 Key features include:
 - `jupyter-book` wrapper, pre- and post-processing steps
-- draft/release workflow
-- manage a local Python http server
+- Draft-Release workflow
+- Manage a local Python http server
+- External Content: include files from other repositories via `_toc.yml`
 
 ### Jupyter Book wrapper and processing steps
 
@@ -35,7 +36,9 @@ To contribute, create a fork and open a pull request to the (default) `develop` 
 
 Semantic numbering is used: `vA.B.C`, where patches advance `C` and minor releases advance `B`. [Releases in the GitHub Repository](https://github.com/TeachBooks/TeachBooks/releases) deploy automatically to [PyPI](https://pypi.org/project/teachbooks/) once a tag is created and the `pyproject.toml` file is updated with the new version number. Minor releases will be merged into the `stable` branch (including those below `v1.0.0`); patches may be incorporated in `develop` or `stable`. 
 
-If a release must be available on PyPI but it is not desired for it to be available as the primary release, use the numbering `vA.B.Cbn`, where `n` is an increasing number starting from 1. The specific version can be installed via pip using `pip install teachbooks==A.B.Cbn`.
+If a release must be available on PyPI but it is not desired for it to be available as the primary release, use the numbering `vA.B.Cbn`, where `n` is an increasing number starting from 1. The specific version can be installed via pip using `pip install teachbooks==A.B.Cbn`. A tag defining this type of release may be used on any branch.
+
+Beginning with `v0.2.0` all tagged releases are available in the Read the Docs website [teachbooks.readthedocs.io](https://teachbooks.readthedocs.io) (described below).
 
 ## Acknowledgements
 
@@ -47,15 +50,11 @@ The first version of this package was created and released by Caspar Jungbacker 
 
 This software will most likely be licensed with a BSD 3-clause license, which aligns with similar Python packages (e.g., Jupyter Book). However, the license file is not yet included with this repository as we are currently in the process of reviewing Copyright status.
 
-## Development
-
-New features and improvements are incorporated via pull requests to the (default) `develop` branch. 
-
 ### Documentation Website
 
 The documentation for this package is built using Sphinx and @pradyunsg's Furo; use the [Furo documentation](https://pradyunsg.me/furo/#) as a reference when updating the documentation site.
 
-The Read the Docs website [teachbooks.readthedocs.io](https://teachbooks.readthedocs.io) maintains documentation for each tagged release beginning with version `0.2.0`. The documentation website is also deployed from GitHub Pages from the `stable` branch and can be accessed at [teachbooks.io/TeachBooks/](https://teachbooks.io/TeachBooks/). This should remain identical to the "latest" (default) Read the Docs documentation page as long as the most recent tagged release is on branch `stable`.
+The Read the Docs website [teachbooks.readthedocs.io](https://teachbooks.readthedocs.io) maintains documentation for each tagged release beginning with `v0.2.0`. The documentation website is also deployed from GitHub Pages from the `stable` branch and can be accessed at [teachbooks.io/TeachBooks/](https://teachbooks.io/TeachBooks/). This should remain identical to the "latest" (default) Read the Docs documentation page as long as the most recent tagged release is on branch `stable`.
 
 ### Development Setup
 

--- a/tests/test_cli_build.py
+++ b/tests/test_cli_build.py
@@ -99,7 +99,6 @@ def test_build_external_content(cli: CliRunner):
     html = book.joinpath("_build", "html")
     assert html.joinpath("index.html").exists()
 
-    # TODO: cleaning this book can make second test book 03 to fail on some systems;
     _ = cli.invoke(commands.clean, ["--external", book.as_posix()])
     assert not html.joinpath("index.html").exists()
     assert not book.joinpath("_git").exists()


### PR DESCRIPTION
With the current (but perhaps not final) setup of `clean` command and the fix for Windows OS things should be stable enough for release, but there are two things to do before we want to advise our users to use this feature so that there won't be confusing changes later:
- [x] change the name of `local_toc.yml`
- [x] make package documentation page visible
- [x] update Manual with guidance in [PR 131](https://github.com/TeachBooks/manual/pull/131)
- [ ] update changelog and release notes in this package

