### PR TITLE
Add Ruff linter

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,25 @@
+name: Static code analysis 🔍️
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.10"
+      - name: Install dependencies
+        run: |
+          python3 -m pip install --upgrade pip wheel
+          pip3 install ruff
+      - name: Ruff Lint
+        run: ruff check --output-format=github .
+    #   - name: Check format
+    #     run: ruff format --check

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -2,7 +2,7 @@ name: Static code analysis 🔍️
 
 on:
   push:
-    branches: [main]
+    branches: [develop, stable]
   pull_request:
     types: [opened, synchronize, reopened]
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -1,5 +1,5 @@
-# Configuration file for the Sphinx documentation builder.
-#
+"""Configuration file for the Sphinx documentation builder."""
+
 # This file only contains a selection of the most common options. For a full
 # list see the documentation:
 # https://www.sphinx-doc.org/en/master/usage/configuration.html
@@ -20,7 +20,7 @@
 from pathlib import Path
 
 project = 'TeachBooks'
-copyright = '2024, the TeachBooks team'
+copyright = '2024, the TeachBooks team'  # noqa: A001
 author = 'TeachBooks'
 
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -19,7 +19,6 @@
 
 from pathlib import Path
 
-
 project = 'TeachBooks'
 copyright = '2024, the TeachBooks team'
 author = 'TeachBooks'

--- a/docs/source/contributing.rst
+++ b/docs/source/contributing.rst
@@ -63,7 +63,10 @@ You want to make some kind of change to the code base
     below.
 #.  make sure the existing documentation can still by generated without
     warnings by running ``cd docs && sphinx-build source/ _build/``.
-#.   add your own tests (if necessary);
+#.  add your own tests (if necessary), and make sure they run when you
+    run the test suite (using the command `pytest`).
+#.  make sure your additions pass the static code analysis. You can run it
+    locally with the command `ruff check`.
 #.  update or expand the documentation; Please add `Google Style Python
     docstrings <https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html>`__.
 #.  `push <http://rogerdudler.github.io/git-guide/>`__ your feature
@@ -95,15 +98,15 @@ The creation of the development environment should be something like this:
     conda deactivate         # Only needed if you have conda
     python3 -m venv venv     # Create a virtual environment
     source venv/bin/activate # or 'venv\Scripts\activate' on Windows
-    pip install -e .[testing,docs]
+    pip install -e .[dev]
     pip show teachbooks      # confirm local installation is used
 
 Using option ``pip install -e`` is editable mode, which updates the
 ``teachbooks`` module in the venv as it is edited. Note that this step
 can take a long time on Windows; the reason is most likely due to malware
 scanners on organization-owned/managed computers. To resolve this you
-should disable the "Realtime malware protection" on your machine. If that
-is not possible, stop and start the installation process several times.
+could (temporarily) disable the "Realtime malware protection" on your machine.
+If that is not possible, stop and start the installation process several times.
 As you can probably already guess, the most effective solution for this
 (and perhaps many of your other open source software problems) is to switch
 to Linux. to avoid this). In general, the `Setuptools manual

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,7 @@ docs = [
 
 [tool.ruff]
 target-version = "py310"
+exclude = ["teachbooks/plugins/*", "*/_ext/*"]
 
 [tool.ruff.lint]
 select = [
@@ -55,6 +56,10 @@ select = [
   "D",
   "DOC",
 ]
+
+[tool.ruff.lint.per-file-ignores]
+"tests/*" = ["D", "DOC", "E501"]
+"*/__init__.py" = ["D104"]
 
 [tool.ruff.lint.pydocstyle]
 convention = "google"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,12 +30,37 @@ testing = [
   "pytest",
   "flaky"
 ]
+dev = [
+  "ruff"
+]
 docs = [
   "furo",
   "numpydoc",
   "sphinxcontrib-apidoc",
   "sphinx-click"
 ]
+
+[tool.ruff]
+target-version = "py310"
+
+[tool.ruff.lint]
+select = [
+  "A",  # builtins
+  "E",
+  "F",
+  "UP",
+  "B",
+  "SIM",
+  "I",  # import sorting
+  "D",
+  "DOC",
+]
+
+[tool.ruff.lint.pydocstyle]
+convention = "google"
+
+[tool.ruff.lint.isort]
+known-first-party = ["teachbooks"]
 
 [tool.setuptools.packages]
 find = {}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,11 +54,10 @@ select = [
   "SIM",
   "I",  # import sorting
   "D",
-  "DOC",
 ]
 
 [tool.ruff.lint.per-file-ignores]
-"tests/*" = ["D", "DOC", "E501"]
+"tests/*" = ["D", "E501"]
 "*/__init__.py" = ["D104"]
 
 [tool.ruff.lint.pydocstyle]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,14 +30,17 @@ testing = [
   "pytest",
   "flaky"
 ]
-dev = [
-  "ruff"
+lint = [
+  "ruff",
 ]
 docs = [
   "furo",
   "numpydoc",
   "sphinxcontrib-apidoc",
   "sphinx-click"
+]
+dev = [
+  "teachbooks[testing,lint,docs]"
 ]
 
 [tool.ruff]

--- a/teachbooks/cli/main.py
+++ b/teachbooks/cli/main.py
@@ -1,8 +1,12 @@
 import shutil
-import click
 from pathlib import Path
-from teachbooks.external_content.process_toc import process_external_toc_entries
-from teachbooks.external_content.process_toc import chmod_git_files
+
+import click
+
+from teachbooks.external_content.process_toc import (
+    chmod_git_files,
+    process_external_toc_entries,
+)
 
 
 @click.group()
@@ -22,9 +26,9 @@ def main():
 @click.pass_context
 def build(ctx, path_source: str, publish: bool, release: bool, process_only: bool):
     """Pre-process book contents and run Jupyter Book build command"""
-    from teachbooks.release import make_release
     from jupyter_book.cli.main import build as jupyter_book_build
-    from teachbooks.release import copy_ext
+
+    from teachbooks.release import copy_ext, make_release
 
     if publish:
         click.secho("Warning: --publish is deprecated, use --release instead",
@@ -76,6 +80,7 @@ def build(ctx, path_source: str, publish: bool, release: bool, process_only: boo
 def clean(path_source, external: bool=False):
     """Stop teachbooks server and run Jupyter Book clean command."""
     from jupyter_book.cli.main import clean as jupyter_book_clean
+
     from teachbooks.serve import Server, ServerError
 
     workdir = Path(path_source) / ".teachbooks" / "server"
@@ -122,23 +127,23 @@ def serve(ctx, verbose):
     If serve dir path not provided, default is `./book/_build/html`.
     Checks to see if server is already running.
     """
+    from teachbooks import BOOK_SERVE_DIR, SERVER_WORK_DIR
     from teachbooks.serve import Server
-    from teachbooks import SERVER_WORK_DIR, BOOK_SERVE_DIR
 
     if verbose > 0:
-        echo_info(f"serve command invoked.")
+        echo_info("serve command invoked.")
 
     if ctx.invoked_subcommand is None:
 
         try:
             server = Server.load(Path(SERVER_WORK_DIR))
             if verbose > 0:
-                echo_info(f" server already exists")
+                echo_info(" server already exists")
             
             stdout_summary(server)
         except:
             if verbose > 0:
-                echo_info(f"no server found, creating a new one.")
+                echo_info("no server found, creating a new one.")
 
             dir = Path(BOOK_SERVE_DIR)
 
@@ -158,8 +163,8 @@ def serve(ctx, verbose):
                 type=click.Path(exists=True, file_okay=True))
 def path(path_source, verbose, no_build=False):
     """Specify relative path of directory to serve."""
-    from teachbooks.serve import Server
     from teachbooks import BUILD_DIR, SERVER_WORK_DIR
+    from teachbooks.serve import Server
     
     if verbose > 0:
         print(f"desired serve directory: {dir}")
@@ -167,7 +172,7 @@ def path(path_source, verbose, no_build=False):
     dir_with_build = Path(path_source).joinpath(BUILD_DIR)
     if dir_with_build.exists():
         dir = dir_with_build
-        echo_info(f"_build/html available and appended to path.")
+        echo_info("_build/html available and appended to path.")
     else:
         dir = Path(path_source)
 
@@ -176,38 +181,38 @@ def path(path_source, verbose, no_build=False):
         server = Server.load(Path(SERVER_WORK_DIR))
         if server.servedir == dir:
             print('            '
-                  +f"  ---> already serving this directory.")
+                  +"  ---> already serving this directory.")
             stdout_summary(server)
         else:
             print('            '
-                  +f"  ---> already serving a different directory.")
+                  +"  ---> already serving a different directory.")
             print('            '
-                  +f"  ---> updating server directory...")
+                  +"  ---> updating server directory...")
             server.stop()
             serve_path(dir, verbose)
     except:
         if verbose > 0:
-            echo_info(f"no server found, creating a new one.")
+            echo_info("no server found, creating a new one.")
         serve_path(dir, verbose)
 
 @serve.command()
 def stop():
     """Stop the webserver."""
-    from teachbooks.serve import Server
     from teachbooks import SERVER_WORK_DIR
+    from teachbooks.serve import Server
     try:
         server = Server.load(Path(SERVER_WORK_DIR))
         server.stop()
-        echo_info(f"server stopped.")
+        echo_info("server stopped.")
     except:
-        echo_info(f"no server found.")
+        echo_info("no server found.")
 
 
 def serve_path(dir: str,
                verbose: int) -> None:
     """Start web server with specific path and verbosity."""
-    from teachbooks.serve import Server
     from teachbooks import SERVER_WORK_DIR
+    from teachbooks.serve import Server
 
     server = Server(servedir=Path(dir),
                     workdir=Path(SERVER_WORK_DIR),
@@ -217,13 +222,13 @@ def serve_path(dir: str,
 
 def check_server():
     """Check if webserver is running and print status."""
-    from teachbooks.serve import Server
     from teachbooks import SERVER_WORK_DIR
+    from teachbooks.serve import Server
     try:
         server = Server.load(Path(SERVER_WORK_DIR))
         stdout_summary(server)
     except:
-        echo_info(f"Use `teachbooks serve` to start a local server.")
+        echo_info("Use `teachbooks serve` to start a local server.")
         
 
 def echo_info(message: str) -> None:

--- a/teachbooks/cli/main.py
+++ b/teachbooks/cli/main.py
@@ -1,3 +1,4 @@
+"""Main CLI module."""
 import shutil
 from pathlib import Path
 
@@ -12,7 +13,7 @@ from teachbooks.external_content.process_toc import (
 @click.group()
 @click.version_option()
 def main():
-    """TeachBooks command line tools"""
+    """TeachBooks command line tools."""
     pass
 
 @main.command(context_settings=dict(
@@ -21,11 +22,13 @@ def main():
 ))
 @click.argument("path-source", type=click.Path(exists=True, file_okay=True))
 @click.option("--release", is_flag=True, help="Build book with release strategy")
-@click.option("--publish", is_flag=True, help="--public is deprecated. Use --release instead.")
+@click.option(
+    "--publish", is_flag=True, help="--public is deprecated. Use --release instead."
+)
 @click.option("--process-only", is_flag=True, help="Only pre-process content")
 @click.pass_context
 def build(ctx, path_source: str, publish: bool, release: bool, process_only: bool):
-    """Pre-process book contents and run Jupyter Book build command"""
+    """Pre-process book contents and run Jupyter Book build command."""
     from jupyter_book.cli.main import build as jupyter_book_build
 
     from teachbooks.release import copy_ext, make_release
@@ -42,7 +45,8 @@ def build(ctx, path_source: str, publish: bool, release: bool, process_only: boo
         path_conf, path_toc = make_release(path_src_folder)
         path_ext = path_src_folder / "_ext"
         if path_ext.exists():
-            echo_info(click.style("copying _ext/ directory to support APA in release [TEMPORARY FEATURE]", fg="yellow"))
+            mg = "copying _ext/ directory to support APA in release [TEMPORARY FEATURE]"
+            echo_info(click.style(mg, fg="yellow"))
             copy_ext(path_src_folder)
     else:
         path_conf = path_src_folder / "_config.yml"
@@ -141,21 +145,36 @@ def serve(ctx, verbose):
                 echo_info(" server already exists")
             
             stdout_summary(server)
-        except:
+        except:  # noqa: E722 TODO: handle more gracefully.
             if verbose > 0:
                 echo_info("no server found, creating a new one.")
 
-            dir = Path(BOOK_SERVE_DIR)
+            serve_dir = Path(BOOK_SERVE_DIR)
 
-            if not dir.exists():
-                echo_info(click.style("default directory not found: ", fg="yellow") + f"{dir}")
-                dir = Path(".")
-                print('            '
-                      +click.style("serving current directory: ", fg="yellow") + f"{dir}")
-                print('            '
-                      +click.style("specify a directory with: 'teachbooks serve path <path>'", fg="yellow"))
+            if not serve_dir.exists():
+                echo_info(
+                    click.style("default directory not found: ", fg="yellow") + 
+                    f"{serve_dir}"
+                )
+
+                serve_dir = Path(".")
+                print(
+                    '            '
+                    + click.style(
+                        "serving current directory: ",
+                        fg="yellow"
+                    )
+                    + f"{serve_dir}"
+                )
+                print(
+                    '            '
+                    + click.style(
+                        "specify a directory with: 'teachbooks serve path <path>'",
+                        fg="yellow"
+                    )
+                )
                 
-            serve_path(dir, verbose)
+            serve_path(serve_dir, verbose)
 
 @serve.command()
 @click.option('-v', '--verbose', count=True)
@@ -165,21 +184,18 @@ def path(path_source, verbose, no_build=False):
     """Specify relative path of directory to serve."""
     from teachbooks import BUILD_DIR, SERVER_WORK_DIR
     from teachbooks.serve import Server
-    
-    if verbose > 0:
-        print(f"desired serve directory: {dir}")
 
     dir_with_build = Path(path_source).joinpath(BUILD_DIR)
     if dir_with_build.exists():
-        dir = dir_with_build
+        serve_dir = dir_with_build
         echo_info("_build/html available and appended to path.")
     else:
-        dir = Path(path_source)
+        serve_dir = Path(path_source)
 
-    echo_info(f"attempting to serve this directory: {dir}")
+    echo_info(f"attempting to serve this directory: {serve_dir}")
     try:
         server = Server.load(Path(SERVER_WORK_DIR))
-        if server.servedir == dir:
+        if server.servedir == serve_dir:
             print('            '
                   +"  ---> already serving this directory.")
             stdout_summary(server)
@@ -189,11 +205,11 @@ def path(path_source, verbose, no_build=False):
             print('            '
                   +"  ---> updating server directory...")
             server.stop()
-            serve_path(dir, verbose)
-    except:
+            serve_path(serve_dir, verbose)
+    except:  # noqa: E722 TODO: handle more gracefully.
         if verbose > 0:
             echo_info("no server found, creating a new one.")
-        serve_path(dir, verbose)
+        serve_path(serve_dir, verbose)
 
 @serve.command()
 def stop():
@@ -204,17 +220,16 @@ def stop():
         server = Server.load(Path(SERVER_WORK_DIR))
         server.stop()
         echo_info("server stopped.")
-    except:
+    except:  # noqa: E722 TODO: handle more gracefully.
         echo_info("no server found.")
 
 
-def serve_path(dir: str,
-               verbose: int) -> None:
+def serve_path(servedir: str, verbose: int) -> None:
     """Start web server with specific path and verbosity."""
     from teachbooks import SERVER_WORK_DIR
     from teachbooks.serve import Server
 
-    server = Server(servedir=Path(dir),
+    server = Server(servedir=Path(servedir),
                     workdir=Path(SERVER_WORK_DIR),
                     stdout=verbose)
     server.start(options=["--all"])
@@ -227,7 +242,7 @@ def check_server():
     try:
         server = Server.load(Path(SERVER_WORK_DIR))
         stdout_summary(server)
-    except:
+    except:  # noqa: E722 TODO: handle more gracefully
         echo_info("Use `teachbooks serve` to start a local server.")
         
 

--- a/teachbooks/external_content/bib.py
+++ b/teachbooks/external_content/bib.py
@@ -106,7 +106,7 @@ def bib_union(bibs: list[BibEntry], additional_bibs: list[BibEntry]):
 
 
 def find(citekey: str, bibs: list[BibEntry]) -> BibEntry:
-    """Find bib entry by citekey"""
+    """Find bib entry by citekey."""
     key_index = [bib.citekey == citekey for bib in bibs].index(True)
     return bibs[key_index]
 
@@ -131,10 +131,7 @@ def merge_bibs(bibfile: Path, repos: list[Path]) -> list[BibEntry]:
     
     Will return an empty list if no reference.bib files are present anywhere.
     """
-    if bibfile.exists():
-        book_bib = read_bibfile(bibfile)
-    else:
-        book_bib = []
+    book_bib = read_bibfile(bibfile) if bibfile.exists() else []
 
     for repo in repos:
         repo_bibfile = find_bibfile(repo)

--- a/teachbooks/external_content/bib.py
+++ b/teachbooks/external_content/bib.py
@@ -1,12 +1,11 @@
 """Functionality to read write and compare .bib files."""
-from dataclasses import dataclass
 import re
+from dataclasses import dataclass
 from pathlib import Path
 
 import click
 
 from teachbooks.external_content.config import CLICK_WARNING_KWARGS
-
 
 BIB_ENTRY_RE = re.compile(r"@(\w+){([\w:-]+)")
 

--- a/teachbooks/external_content/config.py
+++ b/teachbooks/external_content/config.py
@@ -6,7 +6,6 @@ import click
 
 from teachbooks.external_content.utils import load_yaml_file
 
-
 CLICK_WARNING_KWARGS: dict[str, Any] = {"fg": "yellow", "err": True}
 
 

--- a/teachbooks/external_content/config.py
+++ b/teachbooks/external_content/config.py
@@ -1,4 +1,4 @@
-
+"""Parse external content config files."""
 from pathlib import Path
 from typing import Any
 
@@ -9,7 +9,9 @@ from teachbooks.external_content.utils import load_yaml_file
 CLICK_WARNING_KWARGS: dict[str, Any] = {"fg": "yellow", "err": True}
 
 
-def check_plugins(config_file: Path, git_repos: list[Path]) -> tuple[set[str], set[str]]:
+def check_plugins(
+    config_file: Path, git_repos: list[Path]
+) -> tuple[set[str], set[str]]:
     """Check external configs for missing plugins/myst extensions and return them.
 
     The user will be warned if any plugins or extensions are missing/not the same
@@ -165,8 +167,8 @@ def get_myst_extensions(config_file: Path) -> set[str]:
         click.secho(msg, **CLICK_WARNING_KWARGS)
     elif config.get("parse").get("myst_enable_extensions") is None:
         msg = (
-            "Malformed 'parse' entry in config (expected 'myst_enable_extensions' entry),\n"
-            f"    Please check {config_file}"
+            "Malformed 'parse' entry in config (expected 'myst_enable_extensions'"
+            f" entry),\n    Please check {config_file}"
         )
         click.secho(msg, **CLICK_WARNING_KWARGS)
     else:

--- a/teachbooks/external_content/git.py
+++ b/teachbooks/external_content/git.py
@@ -1,3 +1,4 @@
+"""Process git repo URLs."""
 import re
 from pathlib import Path
 

--- a/teachbooks/external_content/git.py
+++ b/teachbooks/external_content/git.py
@@ -1,5 +1,5 @@
-from pathlib import Path
 import re
+from pathlib import Path
 
 
 def get_repo_url(url: str) -> str:

--- a/teachbooks/external_content/headers.py
+++ b/teachbooks/external_content/headers.py
@@ -68,7 +68,6 @@ def add_rst_admonition(file: Path, text: str):
 
 def add_nb_admonition(file: Path, text: str):
     """Add an admonition containing `text` to the top of notebook `file."""
-
     notebook = json.loads(file.read_text(encoding="utf-8"))
 
     admonition_cell = {

--- a/teachbooks/external_content/licenses.py
+++ b/teachbooks/external_content/licenses.py
@@ -1,3 +1,4 @@
+"""Find and validate external content license files."""
 from pathlib import Path
 
 import click

--- a/teachbooks/external_content/licenses.py
+++ b/teachbooks/external_content/licenses.py
@@ -2,7 +2,6 @@ from pathlib import Path
 
 import click
 
-
 LICENSE_MAPPING = {
     "MIT License": "MIT",
     "GNU AFFERO GENERAL PUBLIC LICENSE": "AGPL",

--- a/teachbooks/external_content/process_toc.py
+++ b/teachbooks/external_content/process_toc.py
@@ -1,3 +1,4 @@
+"""Read and process table of contents files."""
 import os.path
 import stat
 import subprocess
@@ -35,9 +36,10 @@ def process_external_toc_entries(
     Args:
         src: Path to the source table-of-contents yaml file.
         dest: Path to the destination table-of-contents yaml file.
-        fail_invalid_license: If true, and no valid license is found in an
+        book_root: Path to the root of the book.
+        error_invalid_license: If true, and no valid license is found in an
             external repository, an error will be raised. Else only a warning.
-    
+
     Returns:
         Path to the new table-of-contents yaml file, or the original file
             if the toc was not modified.
@@ -80,6 +82,7 @@ def process_external_toc_entries(
 
 
 def read_cloned_repos(log: Path) -> list[Path]:
+    """Read in cloned repo file to get paths to all cloned repos."""
     with log.open("r") as f:
         cloned_repos_str = [repo.strip("\n\r") for repo in f.readlines()]
     return [
@@ -89,7 +92,7 @@ def read_cloned_repos(log: Path) -> list[Path]:
 
 
 def get_content_path(url: str) -> str:
-    """Get relative path of the external content from the URL path
+    """Get relative path of the external content from the URL path.
 
     Args:
         url: URL path to the external content
@@ -114,6 +117,7 @@ def write_toc_yaml(
         data: site map
         path: Target `_toc.yml` file path
         encoding: `_toc.yml` file character encoding
+        header: Commented out header to start toc file with.
     """
     with open(path, encoding=encoding, mode="w") as handle:
         if header is not None:

--- a/teachbooks/external_content/process_toc.py
+++ b/teachbooks/external_content/process_toc.py
@@ -16,7 +16,6 @@ from teachbooks.external_content.git import (
     get_branch_tag_name,
     get_repo_url,
 )
-from teachbooks.external_content.git import create_repository_dir_name, get_branch_tag_name, get_repo_url
 from teachbooks.external_content.headers import add_origin_notes
 from teachbooks.external_content.licenses import validate_licenses
 from teachbooks.external_content.requirements import check_requirements

--- a/teachbooks/external_content/process_toc.py
+++ b/teachbooks/external_content/process_toc.py
@@ -1,9 +1,8 @@
 import os.path
 import stat
 import subprocess
-
 from pathlib import Path
-from typing import Any, Dict, Optional
+from typing import Any
 
 import click
 import yaml
@@ -11,11 +10,14 @@ import yaml
 from teachbooks.external_content import GIT_PATH
 from teachbooks.external_content.bib import merge_bibs, write_bibfile
 from teachbooks.external_content.config import check_plugins
-from teachbooks.external_content.git import create_repository_dir_name, get_branch_tag_name, get_repo_url
+from teachbooks.external_content.git import (
+    create_repository_dir_name,
+    get_branch_tag_name,
+    get_repo_url,
+)
 from teachbooks.external_content.licenses import validate_licenses
 from teachbooks.external_content.requirements import check_requirements
 from teachbooks.external_content.utils import load_yaml_file, modify_field
-
 
 LOCAL_TOC_HEADER = (
     "ToC file with localized paths. Used for Teachbooks' external content feature."
@@ -101,10 +103,10 @@ def get_content_path(url: str) -> str:
 
 
 def write_toc_yaml(
-    data: Dict[str, str],
+    data: dict[str, str],
     path: str | Path,
     encoding: str = "utf8",
-    header: Optional[str] = None,
+    header: str | None = None,
 ) -> None:
     """Write a ToC file.
 
@@ -120,10 +122,10 @@ def write_toc_yaml(
 
 
 def external_to_local(
-    mapping: Dict[str, Any],
+    mapping: dict[str, Any],
     external_path: str | Path,
     root: str | Path
-) -> Dict[str, Any]:
+) -> dict[str, Any]:
     """Modify mapping with the "external" key.
 
     Retrieve external components locally, and fix ToC fields accordingly.
@@ -170,7 +172,7 @@ def chmod_git_files(foo, file, err):
     if (
         os.name == "nt" and
         Path(file).suffix in [".idx", ".pack", ".rev"] and
-        "PermissionError" == err[0].__name__
+        err[0].__name__ == "PermissionError"
     ):
         os.chmod(file, stat.S_IWRITE)
         foo(file)

--- a/teachbooks/external_content/requirements.py
+++ b/teachbooks/external_content/requirements.py
@@ -1,3 +1,4 @@
+"""Parse requirements.txt files."""
 from pathlib import Path
 
 import click
@@ -38,7 +39,7 @@ def check_requirements(main_requirements: Path, git_repos: list[Path]):
 
 
 def read_requirements(file: Path) -> set[str]:
-    """Read requirements file and strip comments, index urls, and empty lines"""
+    """Read requirements file and strip comments, index urls, and empty lines."""
     with file.open("r") as f:
         requirements = f.readlines()
     

--- a/teachbooks/external_content/requirements.py
+++ b/teachbooks/external_content/requirements.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+
 import click
 
 
@@ -45,11 +46,7 @@ def read_requirements(file: Path) -> set[str]:
     for req in requirements:
         req = req.strip("\n\r")
 
-        if len(req) == 0:
-            pass
-        elif req.startswith("#"):
-            pass
-        elif req.startswith("--"):
+        if len(req) == 0 or req.startswith("#") or req.startswith("--"):
             pass
         else:
             valid_requirements.add(req.split(" #")[0])

--- a/teachbooks/external_content/utils.py
+++ b/teachbooks/external_content/utils.py
@@ -1,5 +1,6 @@
+from collections.abc import Callable
 from pathlib import Path
-from typing import Any, Callable, Dict, overload
+from typing import Any, overload
 
 import yaml
 
@@ -48,7 +49,7 @@ def modify_field(
 
 def load_yaml_file(
         path: str | Path, encoding: str = "utf8"
-) -> Dict[str, Any]:
+) -> dict[str, Any]:
     """Load a yaml file file (ToC or config) as dictionary.
 
     Args:

--- a/teachbooks/external_content/utils.py
+++ b/teachbooks/external_content/utils.py
@@ -1,3 +1,4 @@
+"""Utilities for external content."""
 from collections.abc import Callable
 from pathlib import Path
 from typing import Any, overload
@@ -29,7 +30,8 @@ def modify_field(
         data: mapping where to look for matches
         key: key to look for
         func: function to run on the matching fields
-        args, kwargs: other positional and keyword arguments for `func`
+        args: positional arguments for `func`
+        kwargs: keyword arguments for `func`
     
     Returns:
         modified mapping

--- a/teachbooks/plugins/pybtex/formatting/apa.py
+++ b/teachbooks/plugins/pybtex/formatting/apa.py
@@ -1,18 +1,25 @@
 # -*- coding:Utf-8 -*-
-from __future__ import unicode_literals
 
 import re
-import six
 
+import six
 from pybtex.plugin import find_plugin
+from pybtex.richtext import Symbol, Text
 from pybtex.style.formatting import BaseStyle, toplevel
 from pybtex.style.template import (
-    field, first_of, href, join, optional, optional_field, sentence, tag,
-    together, words, node, FieldIsMissing
+    FieldIsMissing,
+    field,
+    first_of,
+    href,
+    join,
+    node,
+    optional,
+    optional_field,
+    sentence,
+    tag,
+    together,
+    words,
 )
-
-from pybtex.richtext import Text, Symbol
-
 
 firstlast = find_plugin('pybtex.style.names', 'lastfirst')()
 

--- a/teachbooks/plugins/pybtex/labels/apa.py
+++ b/teachbooks/plugins/pybtex/labels/apa.py
@@ -1,27 +1,24 @@
 # -*- coding:Utf-8 -*-
-from __future__ import unicode_literals
 
-from collections import Counter
 import re
 import unicodedata
+from collections import Counter
 
 from pybtex.style.labels import BaseLabelStyle
-
 
 _nonalnum_pattern = re.compile('[^A-Za-z0-9 \-]+', re.UNICODE)
 
 
 def _strip_accents(s):
     return "".join(
-        (c for c in unicodedata.normalize('NFD', s)
-            if not unicodedata.combining(c)))
+        c for c in unicodedata.normalize('NFD', s)
+            if not unicodedata.combining(c))
 
 
 def _strip_nonalnum(parts):
     """Strip all non-alphanumerical characters from a list of strings.
     
     Example:
-        
         >>> print(_strip_nonalnum([u"ÅA. B. Testing 12+}[.@~_", u" 3%"]))
         AABTesting123
     """
@@ -55,15 +52,12 @@ class APALabelStyle(BaseLabelStyle):
         if 'year' in entry.fields:
             return "{}, {}".format(label, entry.fields['year'])
         else:
-            return "{}, n.d.".format(label)
+            return f"{label}, n.d."
 
     def format_author_or_editor_names(self, persons):
-        if len(persons) is 1:
+        if len(persons) == 1:
             return _strip_nonalnum(persons[0].last_names)
-        elif len(persons) is 2:
-            return "{} & {}".format(
-                _strip_nonalnum(persons[0].last_names),
-                _strip_nonalnum(persons[1].last_names))
+        elif len(persons) == 2:
+            return f"{_strip_nonalnum(persons[0].last_names)} & {_strip_nonalnum(persons[1].last_names)}"
         else:
-            return "{} et al.".format(
-                _strip_nonalnum(persons[0].last_names))
+            return f"{_strip_nonalnum(persons[0].last_names)} et al."

--- a/teachbooks/plugins/pybtex/names/firstlast.py
+++ b/teachbooks/plugins/pybtex/names/firstlast.py
@@ -1,5 +1,4 @@
 # -*- coding:Utf-8 -*-
-from __future__ import unicode_literals
 
 from pybtex.style.names import BaseNameStyle, name_part
 from pybtex.style.template import join
@@ -11,7 +10,6 @@ class FirstLastStyle(BaseNameStyle):
         r"""Format names similarly to {vv~}{ll}{, jj}{, f.} in BibTeX.
 
         Examples:
-            
             >>> from pybtex.database import Person
             >>> name = Person(string=r"Charles Louis Xavier Joseph de la Vall{\'e}e Poussin")
             >>> firstlast = NameStyle().format

--- a/teachbooks/plugins/sphinxcontrib_bibtex/style/referencing/author_year_apa.py
+++ b/teachbooks/plugins/sphinxcontrib_bibtex/style/referencing/author_year_apa.py
@@ -3,6 +3,7 @@ from dataclasses import dataclass, field
 from sphinxcontrib.bibtex.style.referencing import BracketStyle
 from sphinxcontrib.bibtex.style.referencing.author_year import AuthorYearReferenceStyle
 
+
 def bracket_style() -> BracketStyle:
     return BracketStyle(left='(', right=')')
 

--- a/teachbooks/release.py
+++ b/teachbooks/release.py
@@ -1,5 +1,5 @@
-import re
 import os
+import re
 from pathlib import Path
 
 
@@ -68,8 +68,7 @@ def clean_yaml(path_source: str | Path, path_output: str | Path) -> None:
             - file: subdirectory_2/intro_page
 
     """
-
-    with open(path_source, mode="r", encoding="utf8") as f:
+    with open(path_source, encoding="utf8") as f:
         yaml_source = f.read()
 
     # Regex to remove both PUBLISH and RELEASE tags

--- a/teachbooks/release.py
+++ b/teachbooks/release.py
@@ -1,10 +1,11 @@
+"""Teachbooks release workflow."""
 import os
 import re
 from pathlib import Path
 
 
 def make_release(sourcedir: Path) -> tuple[Path, Path]:
-    """Pre-process files in a Jupyter Book directory"""
+    """Pre-process files in a Jupyter Book directory."""
     # Make hidden directory that will contain the cleaned-up files
     workdir = sourcedir.joinpath(".teachbooks", "release")
 
@@ -20,7 +21,7 @@ def make_release(sourcedir: Path) -> tuple[Path, Path]:
     return workdir.joinpath("_config.yml"), workdir.joinpath("_toc.yml")
 
 def copy_ext(sourcedir: Path) -> None:
-    """Copy _ext/ to support APA in release [TEMPORARY]"""
+    """Copy _ext/ to support APA in release [TEMPORARY]."""
     # Make hidden directory that will contain the cleaned-up files
     ext_dir = sourcedir.joinpath("_ext")
     workdir = sourcedir.joinpath(".teachbooks", "release")
@@ -30,16 +31,22 @@ def copy_ext(sourcedir: Path) -> None:
 
     try:
         for root, dirs, files in os.walk(ext_dir):
-            for dir in dirs:
-                os.makedirs(workdir.joinpath("_ext", Path(root).relative_to(ext_dir).joinpath(dir)), exist_ok=True)
+            for _dir in dirs:
+                os.makedirs(
+                    workdir.joinpath(
+                        "_ext", Path(root).relative_to(ext_dir).joinpath(_dir)
+                        ), exist_ok=True
+                )
             for file in files:
                 src_file = Path(root).joinpath(file)
-                dest_file = workdir.joinpath("_ext", Path(root).relative_to(ext_dir).joinpath(file))
+                dest_file = workdir.joinpath(
+                    "_ext", Path(root).relative_to(ext_dir).joinpath(file)
+                )
                 os.makedirs(dest_file.parent, exist_ok=True)
                 with open(src_file, 'rb') as fsrc, open(dest_file, 'wb') as fdst:
                     fdst.write(fsrc.read())
         print("Copied _ext/ directory successfully.")
-    except:
+    except:  # noqa: E722 (TODO: isolate specific exception, or re-raise error.)
         print("Error copying _ext/ directory.")
 
 def clean_yaml(path_source: str | Path, path_output: str | Path) -> None:
@@ -72,8 +79,12 @@ def clean_yaml(path_source: str | Path, path_output: str | Path) -> None:
         yaml_source = f.read()
 
     # Regex to remove both PUBLISH and RELEASE tags
+    re_pub_release = (
+        r"# START REMOVE-FROM-(PUBLISH|RELEASE)(.|\n)*?"
+        r"# END REMOVE-FROM-(PUBLISH|RELEASE)"
+    )
     yaml_output = re.sub(
-        r"# START REMOVE-FROM-(PUBLISH|RELEASE)(.|\n)*?# END REMOVE-FROM-(PUBLISH|RELEASE)",
+        re_pub_release,
         "",
         yaml_source
     )

--- a/teachbooks/serve.py
+++ b/teachbooks/serve.py
@@ -1,3 +1,4 @@
+"""Serve a teachbook locally."""
 import os
 import pickle
 import platform
@@ -20,8 +21,8 @@ Server_t = TypeVar("Server_t", bound="Server")
 
 
 class ServerError(Exception):
-    """Server exception class"""
-    pass
+    """Server exception class."""
+    ...
 
 
 class Server:
@@ -34,7 +35,7 @@ class Server:
                  port: int | None = None,
                  stdout: int | None = None,
                  ) -> None:
-        """Construct Server object
+        """Construct Server object.
 
         Args:
             servedir: Directory to serve.
@@ -97,10 +98,12 @@ class Server:
                 print("Starting server with this command:\n",
                       "  ".join(base_command))
 
-            proc = psutil.Popen([sys.executable, "-u", "-m", "http.server", str(self.port)],
-                                cwd=self.servedir,
-                                stderr=DEVNULL,
-                                stdout=DEVNULL)
+            proc = psutil.Popen(
+                [sys.executable, "-u", "-m", "http.server", str(self.port)],
+                cwd=self.servedir,
+                stderr=DEVNULL,
+                stdout=DEVNULL
+            )
 
             self._pid = proc.pid
 
@@ -109,14 +112,18 @@ class Server:
             # Check if the subprocess is still running
             if not self.is_running:
                 proc.terminate()
-                raise RuntimeError("Error launching the server. Perhaps a server is already running on the selected port?")
+                msg = (
+                    "Error launching the server. Perhaps a server "
+                    "is already running on the selected port?"
+                )
+                raise RuntimeError(msg)
             else:
                 self._save()
 
 
     def stop(self, options: list[str] = None) -> None:
         """Stop server and clean up."""
-        try:
+        try:  # noqa: SIM105 TODO: check if his rule improves this.
             psutil.Process(pid=self._pid).terminate()
         except psutil.NoSuchProcess:
             pass

--- a/teachbooks/serve.py
+++ b/teachbooks/serve.py
@@ -1,12 +1,12 @@
-import pickle
-import sys
 import os
-import socket
+import pickle
 import platform
-from subprocess import DEVNULL
+import socket
+import sys
 from pathlib import Path
-from typing import TypeVar
+from subprocess import DEVNULL
 from time import sleep
+from typing import TypeVar
 
 import psutil
 
@@ -77,13 +77,13 @@ class Server:
         
         if self.is_running:
             if self.stdout is None or self.stdout > 0:
-                print(f"Server already running:")
+                print("Server already running:")
                 print(f"  Serving directory: {self.servedir}")
                 print(f"  Accessible at url: {self.url}")
             return
         else:
             if self.stdout is None or self.stdout > 0:
-                print(f"Starting server:")
+                print("Starting server:")
                 print(f"  Directory: {self.servedir}")
                 print(f"  Port:      {self.port}")
                 print(f"  At url:    {self.url}")

--- a/tests/books/02/_ext/apastyle.py
+++ b/tests/books/02/_ext/apastyle.py
@@ -1,8 +1,9 @@
 
 # from pybtex.style.formatting.unsrt import Style
+from pybtex.plugin import register_plugin
 from pybtexapastyle.formatting.apa import APAStyle
 from pybtexapastyle.labels.apa import LabelStyle as APALabelStyle
-from pybtex.plugin import register_plugin
+
 # from pybtex.style.template import names, sentence
 
 class MyAPALabelStyle(APALabelStyle):

--- a/tests/books/02/_ext/bracket_citation_style.py
+++ b/tests/books/02/_ext/bracket_citation_style.py
@@ -1,6 +1,6 @@
 from dataclasses import dataclass, field
-import sphinxcontrib.bibtex.plugin
 
+import sphinxcontrib.bibtex.plugin
 from sphinxcontrib.bibtex.style.referencing import BracketStyle
 from sphinxcontrib.bibtex.style.referencing.author_year import AuthorYearReferenceStyle
 

--- a/tests/books/02/_ext/pybtexapastyle/formatting/apa.py
+++ b/tests/books/02/_ext/pybtexapastyle/formatting/apa.py
@@ -1,18 +1,25 @@
 # -*- coding:Utf-8 -*-
-from __future__ import unicode_literals
 
 import re
-import six
 
+import six
 from pybtex.plugin import find_plugin
+from pybtex.richtext import Symbol, Text
 from pybtex.style.formatting import BaseStyle, toplevel
 from pybtex.style.template import (
-    field, first_of, href, join, optional, optional_field, sentence, tag,
-    together, words, node, FieldIsMissing
+    FieldIsMissing,
+    field,
+    first_of,
+    href,
+    join,
+    node,
+    optional,
+    optional_field,
+    sentence,
+    tag,
+    together,
+    words,
 )
-
-from pybtex.richtext import Text, Symbol
-
 
 firstlast = find_plugin('pybtex.style.names', 'lastfirst')()
 
@@ -39,8 +46,7 @@ date = words[field('year'), optional[", ", field('month')]]
 
 @node
 def apa_names(children, context, role, **kwargs):
-    """
-    Returns formatted names as an APA compliant reference list citation.
+    """Returns formatted names as an APA compliant reference list citation.
     """
     assert not children
 
@@ -66,8 +72,7 @@ def apa_names(children, context, role, **kwargs):
 
 @node
 def editor_names(children, context, with_suffix=True, **kwargs):
-    """
-    Returns formatted editor names for inbook.
+    """Returns formatted editor names for inbook.
     """
     assert not children
 

--- a/tests/books/02/_ext/pybtexapastyle/formatting/pybtex/style/formatting/__init__.py
+++ b/tests/books/02/_ext/pybtexapastyle/formatting/pybtex/style/formatting/__init__.py
@@ -1,9 +1,8 @@
-from __future__ import unicode_literals
 
-from pybtex.style import FormattedEntry, FormattedBibliography
-from pybtex.style.template import node, join
-from pybtex.richtext import Symbol
 from pybtex.plugin import Plugin, find_plugin
+from pybtex.richtext import Symbol
+from pybtex.style import FormattedBibliography, FormattedEntry
+from pybtex.style.template import join, node
 
 
 @node
@@ -12,8 +11,7 @@ def toplevel(children, data):
 
 
 class BaseStyle(Plugin):
-    """
-    The base class for pythonic formatting styles.
+    """The base class for pythonic formatting styles.
     """
 
     default_name_style = None
@@ -33,7 +31,7 @@ class BaseStyle(Plugin):
     def format_entries(self, entries, bib_data=None):
         sorted_entries = self.sort(entries)
         labels = self.format_labels(sorted_entries)
-        for label, entry in zip(labels, sorted_entries):
+        for label, entry in zip(labels, sorted_entries, strict=False):
             yield self.format_entry(label, entry, bib_data=bib_data)
 
     def format_entry(self, label, entry, bib_data=None):
@@ -43,7 +41,7 @@ class BaseStyle(Plugin):
                 'bib_data': bib_data,
             }
             try:
-                get_template = getattr(self, 'get_{}_template'.format(entry.type))
+                get_template = getattr(self, f'get_{entry.type}_template')
             except AttributeError:
                 format_method = getattr(self, "format_" + entry.type)
                 text = format_method(context)
@@ -52,14 +50,12 @@ class BaseStyle(Plugin):
             return FormattedEntry(entry.key, text, label)
 
     def format_bibliography(self, bib_data, citations=None):
-        """
-        Format bibliography entries with the given keys and return a
+        """Format bibliography entries with the given keys and return a
         ``FormattedBibliography`` object.
 
         :param bib_data: A :py:class:`pybtex.database.BibliographyData` object.
         :param citations: A list of citation keys.
         """
-
         if citations is None:
             citations = list(bib_data.entries.keys())
         citations = bib_data.add_extra_citations(citations, self.min_crossrefs)

--- a/tests/books/02/_ext/pybtexapastyle/formatting/pybtex/style/sorting/__init__.py
+++ b/tests/books/02/_ext/pybtexapastyle/formatting/pybtex/style/sorting/__init__.py
@@ -1,4 +1,3 @@
-from __future__ import unicode_literals
 
 
 from pybtex.plugin import Plugin

--- a/tests/books/02/_ext/pybtexapastyle/formatting/pybtex/style/sorting/author_year_title.py
+++ b/tests/books/02/_ext/pybtexapastyle/formatting/pybtex/style/sorting/author_year_title.py
@@ -1,6 +1,6 @@
-from __future__ import unicode_literals
 
 from pybtex.style.sorting import BaseSortingStyle
+
 
 class SortingStyle(BaseSortingStyle):
 

--- a/tests/books/02/_ext/pybtexapastyle/labels/apa.py
+++ b/tests/books/02/_ext/pybtexapastyle/labels/apa.py
@@ -1,20 +1,18 @@
 # -*- coding:Utf-8 -*-
-from __future__ import unicode_literals
 
-from collections import Counter
 import re
 import unicodedata
+from collections import Counter
 
 from pybtex.style.labels import BaseLabelStyle
-
 
 _nonalnum_pattern = re.compile('[^A-Za-z0-9 \-]+', re.UNICODE)
 
 
 def _strip_accents(s):
     return "".join(
-        (c for c in unicodedata.normalize('NFD', s)
-            if not unicodedata.combining(c)))
+        c for c in unicodedata.normalize('NFD', s)
+            if not unicodedata.combining(c))
 
 
 def _strip_nonalnum(parts):
@@ -59,9 +57,6 @@ class LabelStyle(BaseLabelStyle):
         if len(persons)==1:
             return _strip_nonalnum(persons[0].last_names)
         elif len(persons)==2:
-            return "{} & {}".format(
-                _strip_nonalnum(persons[0].last_names),
-                _strip_nonalnum(persons[1].last_names))
+            return f"{_strip_nonalnum(persons[0].last_names)} & {_strip_nonalnum(persons[1].last_names)}"
         else:
-            return "{} et al.".format(
-                _strip_nonalnum(persons[0].last_names))
+            return f"{_strip_nonalnum(persons[0].last_names)} et al."

--- a/tests/books/02/_ext/pybtexapastyle/names/firstlast.py
+++ b/tests/books/02/_ext/pybtexapastyle/names/firstlast.py
@@ -1,5 +1,4 @@
 # -*- coding:Utf-8 -*-
-from __future__ import unicode_literals
 
 from pybtex.style.names import BaseNameStyle, name_part
 from pybtex.style.template import join
@@ -8,8 +7,7 @@ from pybtex.style.template import join
 class NameStyle(BaseNameStyle):
 
     def format(self, person, abbr=False):
-        r"""
-        Format names similarly to {vv~}{ll}{, jj}{, f.} in BibTeX.
+        r"""Format names similarly to {vv~}{ll}{, jj}{, f.} in BibTeX.
 
         >>> from pybtex.database import Person
         >>> name = Person(string=r"Charles Louis Xavier Joseph de la Vall{\'e}e Poussin")

--- a/tests/books/02/_ext/pybtexapastyle/setup.py
+++ b/tests/books/02/_ext/pybtexapastyle/setup.py
@@ -1,6 +1,5 @@
 import setuptools
 
-
 setuptools.setup(
     name='pybtex-apa-style',
     version='1.3',

--- a/tests/test_cli_build.py
+++ b/tests/test_cli_build.py
@@ -1,10 +1,11 @@
 # Many book-related tests follow that set up in
 # github.com/jupyter-book/jupyter-book/
 from pathlib import Path
+
 import pytest
 from click.testing import CliRunner
-from teachbooks.cli import main as commands
 
+from teachbooks.cli import main as commands
 
 WORK_DIR = Path("./.teachbooks")
 PATH_BOOKS = Path(__file__).parent / "books"

--- a/tests/test_cli_serve.py
+++ b/tests/test_cli_serve.py
@@ -1,6 +1,8 @@
 from pathlib import Path
+
 import pytest
 from click.testing import CliRunner
+
 from teachbooks.cli import main as commands
 
 SERVE_DIR = Path(".")

--- a/tests/test_external_content/__init__.py
+++ b/tests/test_external_content/__init__.py
@@ -3,6 +3,5 @@ from pathlib import Path
 from teachbooks.external_content import GIT_PATH
 from teachbooks.external_content.process_toc import read_cloned_repos
 
-
 BOOK_ROOT = Path(__file__).parent / "testbook" / "book"
 CLONED_REPOS = read_cloned_repos(BOOK_ROOT / GIT_PATH / "cloned_repos.txt")

--- a/tests/test_external_content/test_bibs.py
+++ b/tests/test_external_content/test_bibs.py
@@ -3,9 +3,7 @@ from pathlib import Path
 import pytest
 
 from teachbooks.external_content.bib import merge_bibs, read_bibfile, write_bibfile
-from tests.test_external_content import BOOK_ROOT
-from tests.test_external_content import CLONED_REPOS
-
+from tests.test_external_content import BOOK_ROOT, CLONED_REPOS
 
 TEST_BIBFILE = (
     Path(__file__).parent / "testbook" / "book" / "_git" / 

--- a/tests/test_external_content/test_integration.py
+++ b/tests/test_external_content/test_integration.py
@@ -1,9 +1,10 @@
-from pathlib import Path
 import shutil
+from pathlib import Path
+
 import pytest
 from click.testing import CliRunner
-from teachbooks.cli import main as commands
 
+from teachbooks.cli import main as commands
 
 WORK_DIR = Path(__file__).parent / ".teachbooks"
 PATH_TESTDATA = Path(__file__).parent / "testbook"

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -30,7 +30,7 @@ def test_create(port):
     assert server.servedir == Path(".")
     assert server.workdir == Path("./.teachbooks")
     assert server.port == port
-    assert server._pid == None
+    assert server._pid is None
     assert server._statepath == Path("./.teachbooks/state.pickle")
 
 @flaky(max_runs=10)
@@ -59,7 +59,7 @@ def test_stop(server):
     server.stop()
     
     assert not os.path.exists(WORK_DIR / "state.pickle")
-    assert server._pid == None
+    assert server._pid is None
 
 @flaky(max_runs=10)
 def test_multiple_start(running_server):


### PR DESCRIPTION
This PR adds the Ruff linter and fixes any errors that have come up.

The contributing guide now contains instructions on how to run the linter. I added a `dev` group of extra dependencies, so all the dependencies can be installed by doing `pip install teachbooks[dev]`, which will install `docs,testing,lint`.

The linter has also been added to GH Actions.

Closes #90 