### PR TITLE
Add admonitions to cloned external content pages

### DIFF
--- a/docs/source/external.rst
+++ b/docs/source/external.rst
@@ -27,7 +27,9 @@ Modify your ``_toc.yml`` file by adding an ``external`` entry:
 Upon running ``teachbooks build book/``, the following will happen:
 
 #. The table of content will be parsed to find any "external" keys.
-#. The git repositories corresponding to the "external" keys will be cloned into a subdirectory `_git/`.
+#. The git repositories corresponding to the "external" keys will be cloned into a subdirectory ``_git/``.
+#. Any ``.md``, ``.rst`` or ``.ipynb`` files are modified to include a banner at the top of the page,
+   to denote the file's origin.
 #. The licenses of the repositories are validated. If no (open) license is found, an error is raised.
 #. The ``requirements.txt`` files of the external repositories are checked for any missing values or conflicts.
    If any missing values or conflicts are found, a warning is raised during the build process.

--- a/teachbooks/external_content/headers.py
+++ b/teachbooks/external_content/headers.py
@@ -1,0 +1,90 @@
+"""Add headers to external .md, .rst and .ipynb files."""
+
+import json
+from pathlib import Path
+
+
+def add_origin_notes(repo: Path, base_url: str, version: str) -> None:
+    """Add a note denoting the origin of a certain file.
+
+    Args:
+        repo: Path to the repository git cloned by the enternal-content routine.
+        base_url: Base URL of the file's repository.
+        version: Name of the version (tag, branch or commit hash).
+    """
+    header = (
+        f"This page originates from a TeachBook hosted at {base_url},"
+        f" version: {version}"
+    )
+
+    add_header_admonitions(repo, header)
+
+
+def add_header_admonitions(repo: Path, text: str):
+    """Add header to a file.
+
+    Args:
+        repo: .
+        text: .
+    """
+    md_files = repo.glob("**/*.md")
+    for md_file in md_files:
+        add_md_admonition(md_file, text)
+    
+    rst_files = repo.glob("**/*.rst")
+    for rst_file in rst_files:
+        add_rst_admonition(rst_file, text)
+    
+    nb_files = repo.glob("**/*.ipynb")
+    for nb_file in nb_files:
+        add_nb_admonition(nb_file, text)
+
+
+def prepend(file: Path, text: str):
+    """Prepend string `text` to plaintext file `file`."""
+    with file.open(mode="r") as f:
+        original_content = f.read()
+
+    with file.open(mode="w") as f:
+        f.write(text + original_content)
+
+
+def add_md_admonition(file: Path, text: str):
+    """Add an admonition containing `text` to the top of markdown `file."""
+    admonition = (
+        ":::{attention}\n"
+        f"{text}\n"
+        ":::\n"
+    )
+    prepend(file, admonition)
+
+
+def add_rst_admonition(file: Path, text: str):
+    """Add an admonition containing `text` to the top of reST `file."""
+    admonition = (
+        ".. attention::\n"
+        f"    {text}\n"
+        "\n"
+    )
+    prepend(file, admonition)
+
+
+def add_nb_admonition(file: Path, text: str):
+    """Add an admonition containing `text` to the top of notebook `file."""
+    with file.open("r") as f:
+        notebook = json.load(f)
+    
+    admonition_cell = {
+        "cell_type": "markdown",
+        "metadata": {},
+        "source": [
+            ":::{attention}\n",
+            f"{text}\n",
+            ":::\n",
+        ]
+    }
+
+    notebook["cells"] = [admonition_cell] + notebook["cells"]
+
+    with file.open("w") as f:
+        json.dump(notebook, f)

--- a/teachbooks/external_content/headers.py
+++ b/teachbooks/external_content/headers.py
@@ -42,7 +42,7 @@ def add_header_admonitions(repo: Path, text: str):
 
 def prepend(file: Path, text: str):
     """Prepend string `text` to plaintext file `file`."""
-    original_content = file.read_text()
+    original_content = file.read_text(encoding="utf-8")
     file.write_text(text + original_content, encoding="utf-8")
 
 
@@ -68,8 +68,8 @@ def add_rst_admonition(file: Path, text: str):
 
 def add_nb_admonition(file: Path, text: str):
     """Add an admonition containing `text` to the top of notebook `file."""
-    with file.open("r") as f:
-        notebook = json.load(f)
+
+    notebook = json.loads(file.read_text(encoding="utf-8"))
 
     admonition_cell = {
         "cell_type": "markdown",

--- a/teachbooks/external_content/headers.py
+++ b/teachbooks/external_content/headers.py
@@ -43,7 +43,7 @@ def add_header_admonitions(repo: Path, text: str):
 def prepend(file: Path, text: str):
     """Prepend string `text` to plaintext file `file`."""
     original_content = file.read_text()
-    file.write_text(text + original_content)
+    file.write_text(text + original_content, encoding="utf-8")
 
 
 def add_md_admonition(file: Path, text: str):

--- a/teachbooks/external_content/headers.py
+++ b/teachbooks/external_content/headers.py
@@ -24,17 +24,17 @@ def add_header_admonitions(repo: Path, text: str):
     """Add header to a file.
 
     Args:
-        repo: .
-        text: .
+        repo: Path to the git repo cloned by the external content routine.
+        text: Which text to add to the admonition.
     """
     md_files = repo.glob("**/*.md")
     for md_file in md_files:
         add_md_admonition(md_file, text)
-    
+
     rst_files = repo.glob("**/*.rst")
     for rst_file in rst_files:
         add_rst_admonition(rst_file, text)
-    
+
     nb_files = repo.glob("**/*.ipynb")
     for nb_file in nb_files:
         add_nb_admonition(nb_file, text)
@@ -42,11 +42,8 @@ def add_header_admonitions(repo: Path, text: str):
 
 def prepend(file: Path, text: str):
     """Prepend string `text` to plaintext file `file`."""
-    with file.open(mode="r") as f:
-        original_content = f.read()
-
-    with file.open(mode="w") as f:
-        f.write(text + original_content)
+    original_content = file.read_text()
+    file.write_text(text + original_content)
 
 
 def add_md_admonition(file: Path, text: str):
@@ -73,7 +70,7 @@ def add_nb_admonition(file: Path, text: str):
     """Add an admonition containing `text` to the top of notebook `file."""
     with file.open("r") as f:
         notebook = json.load(f)
-    
+
     admonition_cell = {
         "cell_type": "markdown",
         "metadata": {},

--- a/teachbooks/external_content/process_toc.py
+++ b/teachbooks/external_content/process_toc.py
@@ -12,6 +12,7 @@ from teachbooks.external_content import GIT_PATH
 from teachbooks.external_content.bib import merge_bibs, write_bibfile
 from teachbooks.external_content.config import check_plugins
 from teachbooks.external_content.git import create_repository_dir_name, get_branch_tag_name, get_repo_url
+from teachbooks.external_content.headers import add_origin_notes
 from teachbooks.external_content.licenses import validate_licenses
 from teachbooks.external_content.requirements import check_requirements
 from teachbooks.external_content.utils import load_yaml_file, modify_field
@@ -145,16 +146,26 @@ def external_to_local(
     branch_tag_name = get_branch_tag_name(external_url)
     repository_dir = create_repository_dir_name(external_url, root_dir=external_path)
 
-    if os.path.isdir(repository_dir):
-        click.secho(f"{repository_dir} already exists. Not re-downloading")
+    cloned_repo_file = Path(external_path) / "cloned_repos.txt"
+    if cloned_repo_file.exists():
+        with open(cloned_repo_file) as f:
+            cloned_repos = f.read()
     else:
-        # clone with branch_name
-        subprocess.run([
-            "git", "clone", "--single-branch", "-b",  branch_tag_name, clone_url,
-            repository_dir
-        ])
-        with (Path(external_path) / "cloned_repos.txt").open("a") as f:
+        cloned_repos = []
+
+    if repository_dir in cloned_repos:
+        click.secho(f"{repository_dir} has already been cloned. Not re-downloading")
+    else:
+        # clone with branch_name. Check for environment var (for testing)
+        if "NO_GIT_CLONE" not in os.environ:
+            subprocess.run([
+                "git", "clone", "--single-branch", "-b",  branch_tag_name, clone_url,
+                repository_dir
+            ])
+        with cloned_repo_file.open("a") as f:
             f.write(str(repository_dir) + "\n")
+
+        add_origin_notes(Path(repository_dir), clone_url, version=branch_tag_name)
 
     content_file = get_content_path(external_url)
     rel_path = os.path.relpath(repository_dir, root)

--- a/tests/test_external_content/test_integration.py
+++ b/tests/test_external_content/test_integration.py
@@ -8,6 +8,11 @@ from teachbooks.cli import main as commands
 WORK_DIR = Path(__file__).parent / ".teachbooks"
 PATH_TESTDATA = Path(__file__).parent / "testbook"
 
+ADMONITION_HTML = (
+    "<div class=\"admonition attention\">"
+    "<p class=\"admonition-title\">Attention</p>"
+    "<p>This page originates from a TeachBook hosted at"
+)
 
 @pytest.fixture()
 def cli():
@@ -16,12 +21,21 @@ def cli():
     yield runner
     del runner
 
+def strip_whitespace(text: str) -> str:
+    text = text.replace(" ","")
+    text = text.replace("\n", "")
+    return text.replace("\t","")
+
 
 def test_build(cli: CliRunner, tmp_path: Path, monkeypatch):
     monkeypatch.chdir(tmp_path)  # Fix for windows on CI (otherwise relative dirs fail)
     # Copy test book to temp dir
     testdir: Path = shutil.copytree(PATH_TESTDATA, tmp_path / "test")
     bookdir = testdir / "book"
+
+    # remove cloned_repos.txt file (to make clone routines run)
+    repos = bookdir / "_git" / "cloned_repos.txt"
+    repos.unlink()
 
     # Modify book config to be CI environment compatible
     config = bookdir / "_config.yml"
@@ -32,7 +46,8 @@ def test_build(cli: CliRunner, tmp_path: Path, monkeypatch):
     # Actually run tests
     build_result = cli.invoke(
         commands.build,
-        bookdir.as_posix()
+        bookdir.as_posix(),
+        env={"NO_GIT_CLONE": ""},
     )
     assert build_result.exit_code == 0, build_result.output
 
@@ -43,9 +58,24 @@ def test_build(cli: CliRunner, tmp_path: Path, monkeypatch):
         "github.com_EXCITED-CO2_workshop_tutorial" / "v1.0.0" / "book" /
         "ARCO-ERA5.html"
     )
-    
-    for path in (indexfile, _gitdir, notebook_page):
+    rst_page = (
+        bookdir / "_build" / "html" / "_git" /
+        "github.com_EXCITED-CO2_workshop_tutorial" / "v1.0.0" / "book" /
+        "extra_file.html"
+    )
+    md_page = (
+        bookdir / "_build" / "html" / "_git" /
+        "github.com_TeachBooks_HOS-workbook" / "main" / "book" /
+        "intro.html"
+    )
+
+    for path in (indexfile, _gitdir, notebook_page, rst_page, md_page):
         assert path.exists()
+
+    for page in (notebook_page, rst_page, md_page):
+        page_text = page.read_text()
+        page_text = strip_whitespace(page_text)
+        assert strip_whitespace(ADMONITION_HTML) in page_text
 
     _ = cli.invoke(commands.clean,
                    ['--external',

--- a/tests/test_external_content/test_integration.py
+++ b/tests/test_external_content/test_integration.py
@@ -14,6 +14,7 @@ ADMONITION_HTML = (
     "<p>This page originates from a TeachBook hosted at"
 )
 
+
 @pytest.fixture()
 def cli():
     """Provides a click.testing CliRunner object for invoking CLI commands."""
@@ -21,9 +22,11 @@ def cli():
     yield runner
     del runner
 
+
 def strip_whitespace(text: str) -> str:
     text = text.replace(" ","")
     text = text.replace("\n", "")
+    text = text.replace("\r", "")
     return text.replace("\t","")
 
 

--- a/tests/test_external_content/testbook/book/_toc.yml
+++ b/tests/test_external_content/testbook/book/_toc.yml
@@ -9,3 +9,4 @@ parts:
     - external: https://github.com/TeachBooks/HOS-workbook/blob/main/book/intro.md
     - external: https://gitlab.tudelft.nl/interactivetextbooks-citg/risk-and-reliability/-/blob/v0.1/book/intro.md
     - external: https://gitlab.tudelft.nl/interactivetextbooks-citg/risk-and-reliability/-/blob/main/book/intro.md
+    - external: https://github.com/EXCITED-CO2/workshop_tutorial/blob/v1.0.0/book/extra_file.rst

--- a/tests/test_external_content/testbook/book/_toc_with_local_paths.yml
+++ b/tests/test_external_content/testbook/book/_toc_with_local_paths.yml
@@ -7,4 +7,5 @@ parts:
   - file: _git/github.com_TeachBooks_HOS-workbook/main/book/intro.md
   - file: _git/gitlab.tudelft.nl_interactivetextbooks-citg_risk-and-reliability/v0.1/book/intro.md
   - file: _git/gitlab.tudelft.nl_interactivetextbooks-citg_risk-and-reliability/main/book/intro.md
+  - file: _git/github.com_EXCITED-CO2_workshop_tutorial/v1.0.0/book/extra_file.rst
 root: intro.md


### PR DESCRIPTION
Closes #92 

To comply with attribution licenses and to make end-users aware of which pages are external, teachbooks will now add an admonition to the top of the file to show where the content comes from.

The admonition will look like; 
![image](https://github.com/user-attachments/assets/62257464-e882-4675-9f8e-dfed16726928)

For the gitlab.tudelft.nl pages the full URL is displayed instead of the GH icon (I think the icon comes from some other plugin).