### PR TITLE
Allow configuration of the attribution admonition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ Formatted as described on [https://keepachangelog.com](https://keepachangelog.co
 
 ## Unreleased
 
+## Added
+
+- An admonition will automatically be added on top of external content pages.
+  - The admonition location can be configured (either at top of page or in the right margin).
+  - The color of the admonition can be configured as well.
+
 ## 0.2.0 - 2025-04-07
 
 This release introduces an exciting new feature: automatically including external content in your book!

--- a/teachbooks/external_content/config.py
+++ b/teachbooks/external_content/config.py
@@ -8,6 +8,38 @@ from teachbooks.external_content.utils import load_yaml_file
 
 CLICK_WARNING_KWARGS: dict[str, Any] = {"fg": "yellow", "err": True}
 
+DEFAULT_CONFIG = {
+    "attribution_color": "admonition",  # should refer to a color defined in _config.
+    "attribution_location": "top",  # Either 'top' or 'margin'
+}
+
+
+def get_teachbooks_config(config_file: Path) -> dict[str, str]:
+    """Load teachbooks entries from _config.yml.
+
+    Args:
+        config_file: Path to _config.yml file
+
+    Returns:
+        Loaded configuration.
+    """
+    config = load_yaml_file(config_file)
+
+    cfg = DEFAULT_CONFIG
+    if "teachbooks" in config:
+        if "attribution_color" in config["teachbooks"]:
+            cfg["attribution_color"] = config["teachbooks"]["attribution_color"]
+        if "attribution_location" in config["teachbooks"]:
+            loc = config["teachbooks"]["attribution_location"]
+            if loc not in ["top", "margin"]:
+                msg = (
+                    "Incorrect config location configuration. "
+                    "Should be `top` or `margin`"
+                )
+                raise ValueError(msg)
+            cfg["attribution_location"] = loc
+    return cfg
+
 
 def check_plugins(
     config_file: Path, git_repos: list[Path]

--- a/teachbooks/external_content/headers.py
+++ b/teachbooks/external_content/headers.py
@@ -4,40 +4,58 @@ import json
 from pathlib import Path
 
 
-def add_origin_notes(repo: Path, base_url: str, version: str) -> None:
+def format_header(cfg: dict, base_url: str, version: str) -> str:
+    """Generate the admonition header based on the user's config."""
+    admonition = (
+        "```{" + cfg['attribution_color'] + "} Attribution\n"
+        ":class: attribution\n"
+        f"This page originates from a TeachBook hosted at {base_url},"
+        f" version: {version}\n"
+        "```\n"
+    )
+    if cfg["attribution_location"] == "top":
+        return admonition
+
+    return (
+        "````{margin}\n"
+        f"{admonition}"
+        "````\n"
+    )
+
+
+def add_origin_notes(
+    repo: Path, cfg: dict[str,str], base_url: str, version: str
+) -> None:
     """Add a note denoting the origin of a certain file.
 
     Args:
         repo: Path to the repository git cloned by the enternal-content routine.
+        cfg: TeachBooks configuration.
         base_url: Base URL of the file's repository.
         version: Name of the version (tag, branch or commit hash).
     """
-    header = (
-        f"This page originates from a TeachBook hosted at {base_url},"
-        f" version: {version}"
-    )
-
+    header = format_header(cfg, base_url, version)
     add_header_admonitions(repo, header)
 
 
-def add_header_admonitions(repo: Path, text: str):
+def add_header_admonitions(repo: Path, header: str):
     """Add header to a file.
 
     Args:
         repo: Path to the git repo cloned by the external content routine.
-        text: Which text to add to the admonition.
+        header: Preformatted admonition header
     """
     md_files = repo.glob("**/*.md")
     for md_file in md_files:
-        add_md_admonition(md_file, text)
-
-    rst_files = repo.glob("**/*.rst")
-    for rst_file in rst_files:
-        add_rst_admonition(rst_file, text)
+        prepend(md_file, header)
 
     nb_files = repo.glob("**/*.ipynb")
     for nb_file in nb_files:
-        add_nb_admonition(nb_file, text)
+        add_nb_admonition(nb_file, header)
+
+    rst_files = repo.glob("**/*.rst")
+    for rst_file in rst_files:
+        add_rst_admonition(rst_file, header)
 
 
 def prepend(file: Path, text: str):
@@ -46,38 +64,35 @@ def prepend(file: Path, text: str):
     file.write_text(text + original_content, encoding="utf-8")
 
 
-def add_md_admonition(file: Path, text: str):
-    """Add an admonition containing `text` to the top of markdown `file."""
-    admonition = (
-        ":::{attention}\n"
-        f"{text}\n"
-        ":::\n"
-    )
-    prepend(file, admonition)
+def add_rst_admonition(file: Path, header: str):
+    """Add an admonition top of reST file.
+    
+    To do this we make use of the `include` directive and write the admonition
+    as a separate markdown file which will be parsed by myst.
+    """
+    admon_file = file.parent / f"_ad-{file.stem}.md"
+    admon_file.write_text(header, encoding="utf-8")
 
-
-def add_rst_admonition(file: Path, text: str):
-    """Add an admonition containing `text` to the top of reST `file."""
     admonition = (
-        ".. attention::\n"
-        f"    {text}\n"
+        f".. include:: {admon_file.name}\n"
+        "    :parser: myst_parser.docutils_\n"
         "\n"
     )
     prepend(file, admonition)
 
 
-def add_nb_admonition(file: Path, text: str):
+def add_nb_admonition(file: Path, header: str):
     """Add an admonition containing `text` to the top of notebook `file."""
     notebook = json.loads(file.read_text(encoding="utf-8"))
+
+    # Split over newlines, but add newline char back in at end of lines.
+    source = header.split("\n")
+    source = [line + "\n" for line in source]
 
     admonition_cell = {
         "cell_type": "markdown",
         "metadata": {},
-        "source": [
-            ":::{attention}\n",
-            f"{text}\n",
-            ":::\n",
-        ]
+        "source": source,
     }
 
     notebook["cells"] = [admonition_cell] + notebook["cells"]

--- a/teachbooks/external_content/headers.py
+++ b/teachbooks/external_content/headers.py
@@ -9,7 +9,7 @@ def format_header(cfg: dict, base_url: str, version: str) -> str:
     admonition = (
         "```{" + cfg['attribution_color'] + "} Attribution\n"
         ":class: attribution\n"
-        f"This page originates from a TeachBook hosted at {base_url},"
+        f"This page originates from {base_url},"
         f" version: {version}\n"
         "```\n"
     )

--- a/teachbooks/external_content/process_toc.py
+++ b/teachbooks/external_content/process_toc.py
@@ -10,7 +10,7 @@ import yaml
 
 from teachbooks.external_content import GIT_PATH
 from teachbooks.external_content.bib import merge_bibs, write_bibfile
-from teachbooks.external_content.config import check_plugins
+from teachbooks.external_content.config import check_plugins, get_teachbooks_config
 from teachbooks.external_content.git import (
     create_repository_dir_name,
     get_branch_tag_name,
@@ -143,6 +143,8 @@ def external_to_local(
     Returns:
         map with fields adjusted in order to refer to local resources.
     """
+    cfg = get_teachbooks_config(root / "_config.yml")
+
     mapping_local = mapping.copy()
     external_url = mapping_local.pop("external")
 
@@ -171,7 +173,7 @@ def external_to_local(
         with cloned_repo_file.open("a") as f:
             f.write(str(repository_dir) + "\n")
 
-        add_origin_notes(Path(repository_dir), clone_url, version=branch_tag_name)
+        add_origin_notes(Path(repository_dir), cfg, clone_url, version=branch_tag_name)
 
     content_file = get_content_path(external_url)
     rel_path = os.path.relpath(repository_dir, root)

--- a/tests/test_external_content/test_integration.py
+++ b/tests/test_external_content/test_integration.py
@@ -12,7 +12,7 @@ PATH_TESTDATA = Path(__file__).parent / "testbook"
 ADMONITION_HTML = (
     "<div class=\"attribution admonition\">"
     "<p class=\"admonition-title\">Attribution</p>"
-    "<p>This page originates from a TeachBook hosted at"
+    "<p>This page originates from"
 )
 
 

--- a/tests/test_external_content/test_integration.py
+++ b/tests/test_external_content/test_integration.py
@@ -10,8 +10,8 @@ WORK_DIR = Path(__file__).parent / ".teachbooks"
 PATH_TESTDATA = Path(__file__).parent / "testbook"
 
 ADMONITION_HTML = (
-    "<div class=\"admonition attention\">"
-    "<p class=\"admonition-title\">Attention</p>"
+    "<div class=\"attribution admonition\">"
+    "<p class=\"admonition-title\">Attribution</p>"
     "<p>This page originates from a TeachBook hosted at"
 )
 


### PR DESCRIPTION
This PR adds a "teachbooks" entry to the _config.yml file. In here you can configure the style of the attribution admonition.

For example:
```yaml
sphinx:
  config:
    named_colors_custom_colors: {'attributiongrey':[150,150,150]}
  extra_extensions:
    - sphinx_named_colors

teachbooks:
  attribution_location: margin # (defaults to `top`)
  attribution_color: attributiongrey
```

Will give you @Tom-van-Woudenberg's favorite attribution style, if you have the `_static/attribution.css` file and the `sphinx-named-colors` plugin.

Closes #95 