### PR TITLE
Release 0.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,15 @@ Formatted as described on [https://keepachangelog.com](https://keepachangelog.co
 
 ## Unreleased
 
-## Added
+## 0.2.1 - 2025-05-02
 
-- An admonition will automatically be added on top of external content pages.
-  - The admonition location can be configured (either at top of page or in the right margin).
-  - The color of the admonition can be configured as well.
+### Added
+
+- admonitions which will automatically be added at the top of external content pages ([#96](https://github.com/TeachBooks/TeachBooks/pull/96)).
+  - The admonition location can be configured (either at top of page or in the right margin) ([#98](https://github.com/TeachBooks/TeachBooks/pull/98)).
+  - The color of the admonition can be configured ([#98](https://github.com/TeachBooks/TeachBooks/pull/98)).
+- Automatically generated API docs to the package documentation ([#89](https://github.com/TeachBooks/TeachBooks/pull/89)).
+- 
 
 ## 0.2.0 - 2025-04-07
 

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -27,7 +27,6 @@ institution:
     name: 'TeachBooks'
 license: MIT
 copyright: '© 2025 TeachBooks'
-version: 0.2.0
 date-released: '2025-04-07'
 languages:
     - en

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "teachbooks"
-version = "0.2.0"
+version = "0.2.1"
 description = "TeachBooks wrapper around JupyterBooks"
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
This PR gets the package ready for release 0.2.1

I noticed the citation.cff file also had the version number. This is not required. Removing it reduces the amount of files to modify when making a release.