### PR TITLE
Improve bibtex file parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ Formatted as described on [https://keepachangelog.com](https://keepachangelog.co
 
 ## Unreleased
 
+### Fixed
+
+- Invalid characters in .bib files could cause the external content parser to fail ([#105](https://github.com/TeachBooks/TeachBooks/pull/105)).
+
 ## 0.2.1 - 2025-05-02
 
 ### Added

--- a/teachbooks/external_content/bib.py
+++ b/teachbooks/external_content/bib.py
@@ -21,7 +21,9 @@ class BibEntry:
 
 
 def count_brackets(line: str):
+    """Returns change in curly bracket nesting level on a line of text."""
     return line.count("{") - line.count("}")
+
 
 def read_bibfile(file: Path) -> list[BibEntry]:
     """Read bib file into list of BibEntry objects.
@@ -58,14 +60,14 @@ def read_bibfile(file: Path) -> list[BibEntry]:
             i_eq = line.find("=")  # index of = sign; splits key and value
             if i_eq != -1:
                 key = line[:i_eq].strip()
-                val = line[i_eq + 1 :].strip() # value starts after = sign.
+                val = line[i_eq + 1 :].strip()  # value starts after = sign.
                 val.removeprefix("{")
                 content[key] = val
             elif line.strip() == "}":
                 pass
             else:
                 content[key] += " " + line.strip()
-        
+
         # Strip brackets and trailing commas from finished entries
         for key in content:
             val = content[key].strip()

--- a/teachbooks/external_content/bib.py
+++ b/teachbooks/external_content/bib.py
@@ -20,6 +20,9 @@ class BibEntry:
     content: dict[str, str]
 
 
+def count_brackets(line: str):
+    return max(line.count("{"), 0) - max(line.count("}"), 0)
+
 def read_bibfile(file: Path) -> list[BibEntry]:
     """Read bib file into list of BibEntry objects.
 
@@ -35,39 +38,46 @@ def read_bibfile(file: Path) -> list[BibEntry]:
     lines = [line for line in lines if len(line.strip()) > 0]
 
     entries: list[str] = []
+    bracket_count = 0
     for line in lines:
-        matches = BIB_ENTRY_RE.match(line.strip())
-        if matches:
+        if BIB_ENTRY_RE.match(line.strip()):
             entries.append("")
-        entries[-1] += line
+            bracket_count = count_brackets(line)
+        if bracket_count > 0:
+            entries[-1] += line
+        bracket_count += count_brackets(line)
 
     bib_entries: list[BibEntry] = []
     for entry in entries:
         e = entry.strip().splitlines()
         entrytype, citekey = BIB_ENTRY_RE.findall(e.pop(0))[0]
 
-        content = {}
+        content: dict[str, str] = {}
         for line in e:
             i_eq = line.find("=")  # index of = sign; splits key and value
             if i_eq != -1:
                 key = line[:i_eq].strip()
                 val = line[i_eq + 1 :].strip() # value starts after = sign.
-                val[:-1] # drop trailing comma
-
-                # apparently brackets around the value are optional;
-                if val.startswith("{") and val.endswith("}"):
-                    val = val[1:-1]  # strip brackets
-
+                val.removeprefix("{")
                 content[key] = val
+            elif line.strip() == "}":
+                pass
             else:
                 content[key] += " " + line.strip()
-
+        
+        # Strip brackets and trailing commas from finished entries
+        for key in content:
+            val = content[key].strip()
+            if val.endswith(","):
+                val = val[:-1]
+            if val.startswith("{") and val.endswith("}"):
+                val = val[1:-1]
+            content[key] = val
         if len(content) > 0:
             bib_entries.append(BibEntry(entrytype, citekey, content))
         else:
             msg = f"Malformed entry ({citekey}) found in .bib file: {file}"
             click.secho(msg)
-
     return bib_entries
 
 

--- a/teachbooks/external_content/bib.py
+++ b/teachbooks/external_content/bib.py
@@ -8,7 +8,7 @@ import click
 
 from teachbooks.external_content.config import CLICK_WARNING_KWARGS
 
-BIB_ENTRY_RE = re.compile(r"@(\w+){([\w:-]+)")
+BIB_ENTRY_RE = re.compile(r"@([\w ]+){([\w:-]+)")
 
 
 @dataclass
@@ -31,14 +31,15 @@ def read_bibfile(file: Path) -> list[BibEntry]:
     """
     with file.open("r", encoding="latin-1") as f:
         lines = f.readlines()
+    # strip empty lines
+    lines = [line for line in lines if len(line.strip()) > 0]
 
     entries: list[str] = []
     for line in lines:
-        if len(line.strip()) > 0:
-            matches = BIB_ENTRY_RE.match(line)
-            if matches:
-                entries.append("")
-            entries[-1] += line
+        matches = BIB_ENTRY_RE.match(line.strip())
+        if matches:
+            entries.append("")
+        entries[-1] += line
 
     bib_entries: list[BibEntry] = []
     for entry in entries:
@@ -50,10 +51,16 @@ def read_bibfile(file: Path) -> list[BibEntry]:
             i_eq = line.find("=")  # index of = sign; splits key and value
             if i_eq != -1:
                 key = line[:i_eq].strip()
-                val = line[i_eq + 1 :]
-                leading_br = val.find("{")
-                trailing_br = len(val) - val[::-1].find("}")
-                content[key] = val[leading_br + 1 : trailing_br - 1]
+                val = line[i_eq + 1 :].strip() # value starts after = sign.
+                val[:-1] # drop trailing comma
+
+                # apparently brackets around the value are optional;
+                if val.startswith("{") and val.endswith("}"):
+                    val = val[1:-1]  # strip brackets
+
+                content[key] = val
+            else:
+                content[key] += " " + line.strip()
 
         if len(content) > 0:
             bib_entries.append(BibEntry(entrytype, citekey, content))

--- a/teachbooks/external_content/bib.py
+++ b/teachbooks/external_content/bib.py
@@ -21,7 +21,7 @@ class BibEntry:
 
 
 def count_brackets(line: str):
-    return max(line.count("{"), 0) - max(line.count("}"), 0)
+    return line.count("{") - line.count("}")
 
 def read_bibfile(file: Path) -> list[BibEntry]:
     """Read bib file into list of BibEntry objects.
@@ -38,14 +38,15 @@ def read_bibfile(file: Path) -> list[BibEntry]:
     lines = [line for line in lines if len(line.strip()) > 0]
 
     entries: list[str] = []
-    bracket_count = 0
+    bracket_count = 0  # track { nesting to skip non-entry content.
     for line in lines:
         if BIB_ENTRY_RE.match(line.strip()):
-            entries.append("")
+            entries.append(line)
             bracket_count = count_brackets(line)
-        if bracket_count > 0:
-            entries[-1] += line
-        bracket_count += count_brackets(line)
+        else:
+            if bracket_count > 0:
+                entries[-1] += line
+            bracket_count += count_brackets(line)
 
     bib_entries: list[BibEntry] = []
     for entry in entries:

--- a/teachbooks/external_content/bib.py
+++ b/teachbooks/external_content/bib.py
@@ -29,7 +29,7 @@ def read_bibfile(file: Path) -> list[BibEntry]:
     Returns:
         List of .bib file entries.
     """
-    with file.open("r") as f:
+    with file.open("r", encoding="latin-1") as f:
         lines = f.readlines()
 
     entries: list[str] = []
@@ -113,7 +113,7 @@ def find(citekey: str, bibs: list[BibEntry]) -> BibEntry:
 
 def write_bibfile(file: Path, bibs: list[BibEntry]) -> None:
     """Write a list of BibEntries to a new file."""
-    with open(file, "w") as f:
+    with open(file, mode="w", encoding="latin-1") as f:
         for bib in bibs:
             content_strs = [f"  {key} = {{{val}}}" for key, val in bib.content.items()]
             entry = (

--- a/teachbooks/external_content/process_toc.py
+++ b/teachbooks/external_content/process_toc.py
@@ -62,7 +62,8 @@ def process_external_toc_entries(
         check_plugins(book_root / "_config.yml", cloned_repos)
 
         merged_bibs = merge_bibs(book_root / "references.bib", cloned_repos)
-        write_bibfile(dest.parent / "references.bib", merged_bibs)
+        if len(merged_bibs) > 0:  # only write a file when there are bibtex entries
+            write_bibfile(dest.parent / "references.bib", merged_bibs)
         # TODO: don't overwrite original references.bib file
 
         write_toc_yaml(toc, dest, header=LOCAL_TOC_HEADER)

--- a/tests/test_external_content/test_bibs.py
+++ b/tests/test_external_content/test_bibs.py
@@ -25,7 +25,7 @@ def merged_bibs():
 
 def test_bib_merge(merged_bibs):
     """Ensure test data reference files are merged correctly."""
-    assert len(merged_bibs) == 7  # total unique citekeys
+    assert len(merged_bibs) == 8  # total unique citekeys
 
     expected_entries = [
         "baecher2003",  # duplicate

--- a/tests/test_external_content/testbook/book/references.bib
+++ b/tests/test_external_content/testbook/book/references.bib
@@ -53,3 +53,9 @@
   publisher = {John Wiley \& Sons},
 }
 
+@book{testreference2025,
+  title = {Testing an invalid latin-1 character; ’},
+  author = {Bart},
+  year = {2025},
+  publisher = {TeachBooks},
+}

--- a/tests/test_external_content/testbook/book/references.bib
+++ b/tests/test_external_content/testbook/book/references.bib
@@ -4,7 +4,7 @@
   howpublished = {\url{https://moorepants.github.io/learn-multibody-dynamics/sympy.html}},
   year = {2023},
 }
-
+# ignore me
 @article{sitar1987,
   title = {First-order Reliability Approach to Stochastic Analysis of Subsurface Flow and Contaminant Transport},
   journal = {Water Resources Research},
@@ -14,7 +14,7 @@
   year = {1987},
   author = {Sitar, N. and Cawlfield, J. D. and Der Kiureghian, A.},
 }
-
+==== I'm here to test the bibtex tests.
 @misc{usace14,
   title = {Safety and Health Requirements Manual},
   author = {U.S.{\ }Army{\ }Corps{\ }of{\ }Engineers},


### PR DESCRIPTION
- Fixes #103; Latin-1 encoding should be used for bibtex files. decoding/encoding errors _should_ not occur as every byte value is valid. To ensure this fix works I've added an invalid character to the bibfile used in testing.
- Fixes @FreekPols 's issue where the parser would mangle the Turing Way's references.bib file. 215ec4b changes the parser to be able to read their wonky file.
- Fixes #102; non-entry content in bibtex files are now ignored. 
- Fixes #112; if there are no bib entries, no file is written.