### PR TITLE
fix nested external

### DIFF
--- a/teachbooks/external_content/process_toc.py
+++ b/teachbooks/external_content/process_toc.py
@@ -179,6 +179,13 @@ def external_to_local(
     content_file = get_content_path(external_url)
     rel_path = os.path.relpath(repository_dir, root)
     mapping_local["file"] = os.path.join(rel_path, content_file).replace("\\", "/")
+
+    for k, v in list(mapping_local.items()):
+        if isinstance(v, (dict, list)):
+            mapping_local[k] = modify_field(
+                v, "external", external_to_local, external_path=external_path, root=root
+            )
+    
     return mapping_local
 
 

--- a/teachbooks/external_content/process_toc.py
+++ b/teachbooks/external_content/process_toc.py
@@ -185,7 +185,7 @@ def external_to_local(
             mapping_local[k] = modify_field(
                 v, "external", external_to_local, external_path=external_path, root=root
             )
-    
+
     return mapping_local
 
 

--- a/teachbooks/external_content/process_toc.py
+++ b/teachbooks/external_content/process_toc.py
@@ -181,7 +181,7 @@ def external_to_local(
     mapping_local["file"] = os.path.join(rel_path, content_file).replace("\\", "/")
 
     for k, v in list(mapping_local.items()):
-        if isinstance(v, (dict, list)):
+        if isinstance(v, dict | list):
             mapping_local[k] = modify_field(
                 v, "external", external_to_local, external_path=external_path, root=root
             )

--- a/tests/books/03/book/_toc.yml
+++ b/tests/books/03/book/_toc.yml
@@ -6,7 +6,10 @@ chapters:
   - external: https://github.com/EXCITED-CO2/workshop_tutorial/blob/v1.0.0/book/ARCO-ERA5.ipynb
   - external: https://github.com/TeachBooks/HOS-workbook/blob/main/book/intro.md
   - external: https://gitlab.tudelft.nl/interactivetextbooks-citg/risk-and-reliability/-/blob/v0.1/book/intro.md
-  - external: https://gitlab.tudelft.nl/interactivetextbooks-citg/risk-and-reliability/-/blob/main/book/intro.md
+    sections:
+    - external: https://gitlab.tudelft.nl/interactivetextbooks-citg/risk-and-reliability/-/blob/main/book/intro.md
+      sections:
+      - external: https://github.com/EXCITED-CO2/workshop_tutorial/blob/v1.0.0/book/extra_file.rst
   - external: https://github.com/TeachBooks/manual/blob/release/book/intro/workflow.md
   - external: https://github.com/TeachBooks/template/blob/main/book/some_content/text_and_code.ipynb
   - external: https://github.com/TeachBooks/Nested-Books/blob/manual-description/README.md


### PR DESCRIPTION
# Fix: Recursive Conversion of Nested `external` Keys in ToC

## Summary

This pull request addresses a bug where only the first occurrence of an `external` key in the Table of Contents (ToC) YAML was converted to a local file reference, while any nested `external` keys within child fields (such as sections of a chapter) remained unconverted. Now, all `external` entries—no matter how deeply nested—are correctly converted to local paths.

## Root Cause

Previously, the function responsible for converting `external` keys (`external_to_local`) was only applied to the first level where an `external` key appeared. When an `external` entry was found, it would be replaced with a local `file` reference, but any child fields (like `sections`) within that same mapping were not recursively checked for additional `external` keys. This meant that nested `external` entries would remain untouched, leading to incomplete conversion in more complex ToCs.

## Solution

- Updated `external_to_local` to recursively process all child fields (such as `sections`, `chapters`, etc.) within a mapping after converting an `external` key.
- This ensures that after an `external` key is replaced with a `file` reference, any further `external` keys found deeper in the structure are also properly converted.

## Example

Given the following ToC snippet:

```yaml
- file: ODE/lesson.md
  sections:
  - external: https://github.com/TUDelft-books/CT1000/blob/CTB2210/book/week_2/session_1/intro.ipynb
    sections:
    - external: https://github.com/TUDelft-books/CEG-mechanics-BSc/blob/NL/book/tools/TI-84.md
```

Previously, only the first `external` would be converted. After this fix, both the outer and nested `external` fields will be converted to local `file` references.

## Impact

- Fully supports nested external content references in the ToC.
- No breaking changes to the ToC format or other features.