### PR TITLE
Add language support for attribution headers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ Formatted as described on [https://keepachangelog.com](https://keepachangelog.co
 
 ## Unreleased
 
+## 0.2.3 - 2025-07-18
+
+### Fixed
+
+- Attribution headers are not included in Dutch if the languague setting from the Sphinx configuration is set to `nl` ([#114](https://github.com/TeachBooks/TeachBooks/pull/114))
+
 ## 0.2.2 - 2025-07-15
 
 ### Fixed

--- a/teachbooks/external_content/config.py
+++ b/teachbooks/external_content/config.py
@@ -41,12 +41,7 @@ def get_teachbooks_config(config_file: Path) -> dict[str, str]:
             cfg["attribution_location"] = loc
 
     # Extract language from Sphinx configuration
-    if (
-        "sphinx" in config
-        and "config" in config["sphinx"]
-        and "language" in config["sphinx"]["config"]
-    ):
-        cfg["language"] = config["sphinx"]["config"]["language"]
+    cfg["language"] = config.get("sphinx", {}).get("config", {}).get("language", "en")
 
     return cfg
 

--- a/teachbooks/external_content/config.py
+++ b/teachbooks/external_content/config.py
@@ -39,6 +39,12 @@ def get_teachbooks_config(config_file: Path) -> dict[str, str]:
                 )
                 raise ValueError(msg)
             cfg["attribution_location"] = loc
+    
+    # Extract language from Sphinx configuration
+    if "sphinx" in config and "config" in config["sphinx"]:
+        if "language" in config["sphinx"]["config"]:
+            cfg["language"] = config["sphinx"]["config"]["language"]
+    
     return cfg
 
 

--- a/teachbooks/external_content/config.py
+++ b/teachbooks/external_content/config.py
@@ -41,7 +41,11 @@ def get_teachbooks_config(config_file: Path) -> dict[str, str]:
             cfg["attribution_location"] = loc
     
     # Extract language from Sphinx configuration
-    if "sphinx" in config and "config" in config["sphinx"] and "language" in config["sphinx"]["config"]:
+    if (
+        "sphinx" in config
+        and "config" in config["sphinx"]
+        and "language" in config["sphinx"]["config"]
+    ):
         cfg["language"] = config["sphinx"]["config"]["language"]
     
     return cfg

--- a/teachbooks/external_content/config.py
+++ b/teachbooks/external_content/config.py
@@ -41,9 +41,8 @@ def get_teachbooks_config(config_file: Path) -> dict[str, str]:
             cfg["attribution_location"] = loc
     
     # Extract language from Sphinx configuration
-    if "sphinx" in config and "config" in config["sphinx"]:
-        if "language" in config["sphinx"]["config"]:
-            cfg["language"] = config["sphinx"]["config"]["language"]
+    if "sphinx" in config and "config" in config["sphinx"] and "language" in config["sphinx"]["config"]:
+        cfg["language"] = config["sphinx"]["config"]["language"]
     
     return cfg
 

--- a/teachbooks/external_content/config.py
+++ b/teachbooks/external_content/config.py
@@ -39,7 +39,7 @@ def get_teachbooks_config(config_file: Path) -> dict[str, str]:
                 )
                 raise ValueError(msg)
             cfg["attribution_location"] = loc
-    
+
     # Extract language from Sphinx configuration
     if (
         "sphinx" in config
@@ -47,7 +47,7 @@ def get_teachbooks_config(config_file: Path) -> dict[str, str]:
         and "language" in config["sphinx"]["config"]
     ):
         cfg["language"] = config["sphinx"]["config"]["language"]
-    
+
     return cfg
 
 

--- a/teachbooks/external_content/headers.py
+++ b/teachbooks/external_content/headers.py
@@ -6,13 +6,28 @@ from pathlib import Path
 
 def format_header(cfg: dict, base_url: str, version: str) -> str:
     """Generate the admonition header based on the user's config."""
-    admonition = (
-        "```{" + cfg["attribution_color"] + "} Attribution\n"
-        ":class: attribution\n"
-        f"This page originates from {base_url},"
-        f" version: {version}\n"
-        "```\n"
-    )
+    # Check if language is set to Dutch in the configuration
+    language = cfg.get("language", "en")
+    
+    if language == "nl":
+        # Dutch attribution text
+        admonition = (
+            "```{" + cfg["attribution_color"] + "} Bronvermelding\n"
+            ":class: attribution\n"
+            f"Deze pagina is afkomstig van {base_url},"
+            f" versie: {version}\n"
+            "```\n"
+        )
+    else:
+        # Default English attribution text
+        admonition = (
+            "```{" + cfg["attribution_color"] + "} Attribution\n"
+            ":class: attribution\n"
+            f"This page originates from {base_url},"
+            f" version: {version}\n"
+            "```\n"
+        )
+    
     if cfg["attribution_location"] == "top":
         return admonition
 

--- a/teachbooks/external_content/headers.py
+++ b/teachbooks/external_content/headers.py
@@ -8,7 +8,7 @@ def format_header(cfg: dict, base_url: str, version: str) -> str:
     """Generate the admonition header based on the user's config."""
     # Check if language is set to Dutch in the configuration
     language = cfg.get("language", "en")
-    
+
     if language == "nl":
         # Dutch attribution text
         admonition = (
@@ -27,7 +27,7 @@ def format_header(cfg: dict, base_url: str, version: str) -> str:
             f" version: {version}\n"
             "```\n"
         )
-    
+
     if cfg["attribution_location"] == "top":
         return admonition
 

--- a/teachbooks/external_content/headers.py
+++ b/teachbooks/external_content/headers.py
@@ -12,7 +12,7 @@ def format_header(cfg: dict, base_url: str, version: str) -> str:
     if language == "nl":
         # Dutch attribution text
         admonition = (
-            "```{" + cfg["attribution_color"] + "} Bronvermelding\n"
+            f"```{{{cfg['attribution_color']}}} Bronvermelding\n"
             ":class: attribution\n"
             f"Deze pagina is afkomstig van {base_url},"
             f" versie: {version}\n"


### PR DESCRIPTION
Extracts the 'language' setting from the Sphinx configuration and uses it to localize the attribution header. Currently, Dutch ('nl') is supported with a translated header; otherwise, English is used by default.