### PR TITLE
Issue 127

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ Formatted as described on [https://keepachangelog.com](https://keepachangelog.co
 
 ## Unreleased
 
+## 0.2.4 - 2026-01-05
+
+### Fixed
+
+- Adjustments to Markdown and RST header insertion to preserve YAML front-matter ([#128](https://github.com/TeachBooks/TeachBooks/pull/128)).
+
 ## 0.2.3 - 2025-11-07
 
 ### Changed
@@ -18,7 +24,7 @@ Formatted as described on [https://keepachangelog.com](https://keepachangelog.co
 - Quirky formatted .bib files would cause build failure ([#105](https://github.com/TeachBooks/TeachBooks/pull/105)).
 - Non entry content in .bib files is now skipped ([#105](https://github.com/TeachBooks/TeachBooks/pull/105)).
 - If there are no bib entries in external content or the main references file, no empty references.bib file is written ([#105](https://github.com/TeachBooks/TeachBooks/pull/105)).
-- Attribution headers are not included in Dutch if the languague setting from the Sphinx configuration is set to `nl` ([#114](https://github.com/TeachBooks/TeachBooks/pull/114)).
+- Attribution headers are not included in Dutch if the language setting from the Sphinx configuration is set to `nl` ([#114](https://github.com/TeachBooks/TeachBooks/pull/114)).
 - Removed .git suffix from attribution header URLs ([#119](https://github.com/TeachBooks/TeachBooks/pull/119)).
 
 ## 0.2.2 - 2025-07-15

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "teachbooks"
-version = "0.2.3"
+version = "0.2.4"
 description = "TeachBooks wrapper around JupyterBooks"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/teachbooks/external_content/headers.py
+++ b/teachbooks/external_content/headers.py
@@ -93,12 +93,14 @@ def prepend(file: Path, text: str):
         new_content = text + original_content
     file.write_text(new_content, encoding="utf-8")
 
+
 def add_md_admonition(file: Path, header: str):
     """Add an admonition containing `text` to the top of markdown file `file`."""
     start_of_header_comment = "<!-- Start of inserted Teachbooks header -->"
     end_of_header_comment = "<!-- End of inserted Teachbooks header -->"
     header = f"{start_of_header_comment}\n\n{header}\n\n{end_of_header_comment}\n\n"
     prepend(file, header)
+
 
 def add_rst_admonition(file: Path, header: str):
     """Add an admonition top of reST file.

--- a/teachbooks/external_content/headers.py
+++ b/teachbooks/external_content/headers.py
@@ -58,7 +58,7 @@ def add_header_admonitions(repo: Path, header: str):
     """
     md_files = repo.glob("**/*.md")
     for md_file in md_files:
-        prepend(md_file, header)
+        add_md_admonition(md_file, header)
 
     nb_files = repo.glob("**/*.ipynb")
     for nb_file in nb_files:
@@ -93,12 +93,20 @@ def prepend(file: Path, text: str):
         new_content = text + original_content
     file.write_text(new_content, encoding="utf-8")
 
+def add_md_admonition(file: Path, header: str):
+    """Add an admonition containing `text` to the top of markdown file `file`."""
+    start_original_content = "<!-- Start original content -->"
+    header += f"\n\n{start_original_content}\n\n"
+    prepend(file, header)
+
 def add_rst_admonition(file: Path, header: str):
     """Add an admonition top of reST file.
 
     To do this we make use of the `include` directive and write the admonition
     as a separate markdown file which will be parsed by myst.
     """
+    start_original_content = ".. Start original content"
+    header += f"\n\n{start_original_content}\n\n"
     admon_file = file.parent / f"_ad-{file.stem}.md"
     admon_file.write_text(header, encoding="utf-8")
 

--- a/teachbooks/external_content/headers.py
+++ b/teachbooks/external_content/headers.py
@@ -72,8 +72,26 @@ def add_header_admonitions(repo: Path, header: str):
 def prepend(file: Path, text: str):
     """Prepend string `text` to plaintext file `file`."""
     original_content = file.read_text(encoding="utf-8")
-    file.write_text(text + original_content, encoding="utf-8")
+    lines = original_content.splitlines()
+    # Check if original_content contains a YAML top-matter metadata
+    if lines[0] == "---":
+        # Find the position of the closing `---`
+        for i in range(1, len(lines)):
+            if lines[i] == "---":
+                # Insert after this line
+                insert_pos = i + 1
+                break
+        else:
+            insert_pos = 0  # No closing `---` found, treat as no YAML front matter
 
+        # Reconstruct the content with the new text inserted after the YAML front matter
+        yaml_content = "\n".join(lines[:insert_pos]) + "\n"
+        rest_content = "\n".join(lines[insert_pos:])
+
+        new_content = yaml_content + text + rest_content
+    else:
+        new_content = text + original_content
+    file.write_text(new_content, encoding="utf-8")
 
 def add_rst_admonition(file: Path, header: str):
     """Add an admonition top of reST file.

--- a/teachbooks/external_content/headers.py
+++ b/teachbooks/external_content/headers.py
@@ -95,8 +95,9 @@ def prepend(file: Path, text: str):
 
 def add_md_admonition(file: Path, header: str):
     """Add an admonition containing `text` to the top of markdown file `file`."""
+    start_of_header_comment = "<!-- Start of inserted Teachbooks header -->"
     end_of_header_comment = "<!-- End of inserted Teachbooks header -->"
-    header += f"\n\n{end_of_header_comment}\n\n"
+    header = f"{start_of_header_comment}\n\n{header}\n\n{end_of_header_comment}\n\n"
     prepend(file, header)
 
 def add_rst_admonition(file: Path, header: str):
@@ -105,8 +106,9 @@ def add_rst_admonition(file: Path, header: str):
     To do this we make use of the `include` directive and write the admonition
     as a separate markdown file which will be parsed by myst.
     """
+    start_of_header_comment = ".. Start of inserted Teachbooks header"
     end_of_header_comment = ".. End of inserted Teachbooks header"
-    header += f"\n\n{end_of_header_comment}\n\n"
+    header = f"{start_of_header_comment}\n\n{header}\n\n{end_of_header_comment}\n\n"
     admon_file = file.parent / f"_ad-{file.stem}.md"
     admon_file.write_text(header, encoding="utf-8")
 

--- a/teachbooks/external_content/headers.py
+++ b/teachbooks/external_content/headers.py
@@ -95,8 +95,8 @@ def prepend(file: Path, text: str):
 
 def add_md_admonition(file: Path, header: str):
     """Add an admonition containing `text` to the top of markdown file `file`."""
-    start_original_content = "<!-- Start original content -->"
-    header += f"\n\n{start_original_content}\n\n"
+    end_of_header_comment = "<!-- End of inserted Teachbooks header -->"
+    header += f"\n\n{end_of_header_comment}\n\n"
     prepend(file, header)
 
 def add_rst_admonition(file: Path, header: str):
@@ -105,8 +105,8 @@ def add_rst_admonition(file: Path, header: str):
     To do this we make use of the `include` directive and write the admonition
     as a separate markdown file which will be parsed by myst.
     """
-    start_original_content = ".. Start original content"
-    header += f"\n\n{start_original_content}\n\n"
+    end_of_header_comment = ".. End of inserted Teachbooks header"
+    header += f"\n\n{end_of_header_comment}\n\n"
     admon_file = file.parent / f"_ad-{file.stem}.md"
     admon_file.write_text(header, encoding="utf-8")
 

--- a/teachbooks/external_content/headers.py
+++ b/teachbooks/external_content/headers.py
@@ -74,7 +74,7 @@ def prepend(file: Path, text: str):
     original_content = file.read_text(encoding="utf-8")
     lines = original_content.splitlines()
     # Check if original_content contains a YAML top-matter metadata
-    if lines[0] == "---":
+    if len(lines) > 0 and lines[0] == "---":
         # Find the position of the closing `---`
         for i in range(1, len(lines)):
             if lines[i] == "---":

--- a/tests/test_external_content/test_integration.py
+++ b/tests/test_external_content/test_integration.py
@@ -1,6 +1,6 @@
 import shutil
-from pathlib import Path
 import traceback
+from pathlib import Path
 
 import pytest
 from click.testing import CliRunner

--- a/tests/test_external_content/test_integration.py
+++ b/tests/test_external_content/test_integration.py
@@ -1,5 +1,6 @@
 import shutil
 from pathlib import Path
+import traceback
 
 import pytest
 from click.testing import CliRunner
@@ -53,6 +54,9 @@ def test_build(cli: CliRunner, tmp_path: Path, monkeypatch):
         bookdir.as_posix(),
         env={"NO_GIT_CLONE": ""},
     )
+
+    if build_result.exit_code == 1:
+        traceback.print_tb(build_result.exc_info[2])
     assert build_result.exit_code == 0, build_result.output
 
     indexfile = bookdir / "_build" / "html" / "index.html"


### PR DESCRIPTION
This pull request refactors how header admonitions are inserted into Markdown and reStructuredText (RST) files to improve clarity and maintainability. The main changes include introducing explicit comment markers around inserted headers, ensuring compatibility with YAML front matter in Markdown files, and centralizing logic for Markdown admonition insertion.

**Improvements to Markdown header insertion:**
- Added a new `add_md_admonition` function to wrap inserted headers in HTML comment markers for easier identification and future removal. The `add_header_admonitions` function now uses this instead of calling `prepend` directly. [[1]](diffhunk://#diff-d4bd2609577431ad3429e3fc74ce068db209b00004d973fc3a841d35c21bc193L61-R61) [[2]](diffhunk://#diff-d4bd2609577431ad3429e3fc74ce068db209b00004d973fc3a841d35c21bc193L75-R102)
- Updated the `prepend` function to detect YAML front matter in Markdown files and insert the header after it, preserving document metadata.

**Improvements to RST header insertion:**
- Modified `add_rst_admonition` to wrap inserted headers in comment markers, making them easy to identify in generated files.